### PR TITLE
Replaced deprecated ref-values in rule-tags, minor bug fix, *.apxc support

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
             {
                 "id": "apex",
                 "extensions": [
+                    ".apxc",
                     ".cls",
                     ".trigger"
                 ],

--- a/rulesets/apex_ruleset.xml
+++ b/rulesets/apex_ruleset.xml
@@ -10,7 +10,7 @@
 	</description>
 
 
-	<rule ref="rulesets/apex/apexunit.xml/ApexUnitTestClassShouldHaveAsserts" message="Apex unit tests should include at least one assertion.  This makes the tests more robust, and using assert
+	<rule ref="category/apex/bestpractices.xml/ApexUnitTestClassShouldHaveAsserts" message="Apex unit tests should include at least one assertion.  This makes the tests more robust, and using assert
         with messages provide the developer a clearer idea of what the test does.">
 		<priority>3</priority>
 
@@ -22,7 +22,7 @@
     	</properties>
 	</rule>
 
-	<rule ref="rulesets/apex/apexunit.xml/ApexUnitTestShouldNotUseSeeAllDataTrue" message="Apex unit tests should not use @isTest(seeAllData=true) because it opens up the existing database data for unexpected modification by tests.">
+	<rule ref="category/apex/bestpractices.xml/ApexUnitTestShouldNotUseSeeAllDataTrue" message="Apex unit tests should not use @isTest(seeAllData=true) because it opens up the existing database data for unexpected modification by tests.">
 		<priority>3</priority>
 
 		<properties>
@@ -33,7 +33,7 @@
     	</properties>
 	</rule>
 
-	<rule ref="rulesets/apex/complexity.xml/ExcessiveClassLength" message="Avoid really long classes (lines of code)">
+	<rule ref="category/apex/design.xml/ExcessiveClassLength" message="Avoid really long classes (lines of code)">
 		<priority>3</priority>
 
 		<properties>
@@ -46,7 +46,7 @@
     	</properties>
 	</rule>
 
-	<rule ref="rulesets/apex/complexity.xml/ExcessiveClassLength" message="Avoid really long classes (lines of code)">
+	<rule ref="category/apex/design.xml/ExcessiveClassLength" message="Avoid really long classes (lines of code)">
 		<priority>3</priority>
 
 		<properties>
@@ -59,7 +59,7 @@
     	</properties>
 	</rule>
 
-	<rule ref="rulesets/apex/complexity.xml/ExcessiveParameterList" message="Avoid long parameter lists">
+	<rule ref="category/apex/design.xml/ExcessiveParameterList" message="Avoid long parameter lists">
 		<priority>3</priority>
 
 		<properties>
@@ -72,7 +72,7 @@
     	</properties>
 	</rule>
 
-	<rule ref="rulesets/apex/complexity.xml/ExcessivePublicCount" message="This class has too many public methods and attributes">
+	<rule ref="category/apex/design.xml/ExcessivePublicCount" message="This class has too many public methods and attributes">
 		<priority>3</priority>
 
 		<properties>
@@ -85,7 +85,7 @@
     	</properties>
 	</rule>
 
-	<rule ref="rulesets/apex/complexity.xml/NcssConstructorCount" message="The constructor has an NCSS line count of {0}">
+	<rule ref="category/apex/design.xml/NcssConstructorCount" message="The constructor has an NCSS line count of {0}">
 		<priority>3</priority>
 
 		<properties>
@@ -98,7 +98,7 @@
     	</properties>
 	</rule>
 
-	<rule ref="rulesets/apex/complexity.xml/NcssMethodCount" message="The method {0}() has an NCSS line count of {1}">
+	<rule ref="category/apex/design.xml/NcssMethodCount" message="The method {0}() has an NCSS line count of {1}">
 		<priority>3</priority>
 
 		<properties>
@@ -111,7 +111,7 @@
     	</properties>
 	</rule>
 
-	<rule ref="rulesets/apex/complexity.xml/NcssTypeCount" message="The type has an NCSS line count of {0}">
+	<rule ref="category/apex/design.xml/NcssTypeCount" message="The type has an NCSS line count of {0}">
 		<priority>3</priority>
 
 		<properties>
@@ -124,7 +124,7 @@
     	</properties>
 	</rule>
 
-	<rule ref="rulesets/apex/complexity.xml/StdCyclomaticComplexity" message="The {0} ''{1}'' has a Standard Cyclomatic Complexity of {2}.">
+	<rule ref="category/apex/design.xml/StdCyclomaticComplexity" message="The {0} ''{1}'' has a Standard Cyclomatic Complexity of {2}.">
 		<priority>3</priority>
 
 		<properties>
@@ -137,7 +137,7 @@
     	</properties>
 	</rule>
 
-	<rule ref="rulesets/apex/complexity.xml/TooManyFields" message="Too many fields">
+	<rule ref="category/apex/design.xml/TooManyFields" message="Too many fields">
 		<priority>3</priority>
 
 		<properties>
@@ -150,7 +150,7 @@
     	</properties>
 	</rule>
 
-	<rule ref="rulesets/apex/complexity.xml/AvoidDeeplyNestedIfStmts" message="Deeply nested if..else statements are hard to read">
+	<rule ref="category/apex/design.xml/AvoidDeeplyNestedIfStmts" message="Deeply nested if..else statements are hard to read">
 		<priority>3</priority>
 		<properties>
         	<property name="problemDepth" value="4"/>
@@ -163,7 +163,7 @@
 	</rule>
 
 
-	<rule ref="rulesets/apex/performance.xml/AvoidSoqlInLoops" message="Avoid Soql queries inside loops">
+	<rule ref="category/apex/performance.xml/AvoidSoqlInLoops" message="Avoid Soql queries inside loops">
 		<priority>1</priority>
 
         <properties>
@@ -174,7 +174,7 @@
        	</properties>
 	</rule>
 
-	<rule ref="rulesets/apex/performance.xml/AvoidDmlStatementsInLoops" message="Avoid Soql queries inside loops">
+	<rule ref="category/apex/performance.xml/AvoidDmlStatementsInLoops" message="Avoid Soql queries inside loops">
 		<priority>1</priority>
 
         <properties>
@@ -185,7 +185,7 @@
        	</properties>
 	</rule>
 
-	<rule ref="rulesets/apex/style.xml/AvoidLogicInTrigger" message="Avoid logic in triggers">
+	<rule ref="category/apex/bestpractices.xml/AvoidLogicInTrigger" message="Avoid logic in triggers">
 		<priority>3</priority>
 
         <properties>
@@ -196,7 +196,7 @@
        	</properties>
 	</rule>
 
-	<rule ref="rulesets/apex/style.xml/AvoidGlobalModifier" message="Avoid using global modifier">
+	<rule ref="category/apex/bestpractices.xml/AvoidGlobalModifier" message="Avoid using global modifier">
 		<priority>3</priority>
 
 		<properties>
@@ -207,7 +207,7 @@
        	</properties>
 	</rule>
 
-	<rule ref="rulesets/apex/style.xml/ClassNamingConventions" message="Class names should begin with an uppercase character">
+	<rule ref="category/apex/codestyle.xml/ClassNamingConventions" message="Class names should begin with an uppercase character">
 		<priority>3</priority>
 
         <properties>
@@ -218,7 +218,7 @@
        	</properties>
 	</rule>
 
-	<rule ref="rulesets/apex/style.xml/MethodNamingConventions"
+	<rule ref="category/apex/codestyle.xml/MethodNamingConventions"
 		  message="Method name does not begin with a lower case character.">
 		<priority>3</priority>
 
@@ -230,7 +230,7 @@
        	</properties>
 	</rule>
 
-	<rule ref="rulesets/apex/style.xml/MethodWithSameNameAsEnclosingClass" message="Classes should not have non-constructor methods with the same name as the class">
+	<rule ref="category/apex/errorprone.xml/MethodWithSameNameAsEnclosingClass" message="Classes should not have non-constructor methods with the same name as the class">
 		<priority>3</priority>
 
         <properties>
@@ -241,7 +241,7 @@
        	</properties>
 	</rule>
 
-	<rule ref="rulesets/apex/style.xml/VariableNamingConventions" message="{0} variable {1} should begin with {2}">
+	<rule ref="category/apex/codestyle.xml/VariableNamingConventions" message="{0} variable {1} should begin with {2}">
 		<priority>3</priority>
 
         <properties>

--- a/src/lib/apexPmd.ts
+++ b/src/lib/apexPmd.ts
@@ -33,6 +33,7 @@ export class ApexPmd{
             let problemsMap = new Map<string,Array<vscode.Diagnostic>>();
             for(let i = 0; i < lines.length; i++){
                 try{
+                    if(!lines[i]) continue;
                     let file = this.getFilePath(lines[i]);
 
                     let problem = this.createDiagonistic(lines[i]);
@@ -47,27 +48,29 @@ export class ApexPmd{
                     this._outputChannel.appendLine(ex);
                 }
             }
-            problemsMap.forEach(function(value, key){
-                let uri = vscode.Uri.file(key);
-                vscode.workspace.openTextDocument(uri).then(doc => {
-                    //fix ranges to not include whitespace
-                    for(let i = 0; i < value.length; i++){
-                        let prob = value[i];
-                        let line = doc.lineAt(prob.range.start.line);
-                        prob.range = new vscode.Range(
-                                        new vscode.Position(line.range.start.line, line.firstNonWhitespaceCharacterIndex),
-                                        line.range.end
-                                    );
-                    }
-                    collection.delete(uri);
-                    collection.set(uri , value);
-                }, reason => {
-                    console.log(reason);
-                    this._outputChannel.appendLine(reason);
+            if(problemsMap.size > 0){
+                problemsMap.forEach(function(value, key){
+                    let uri = vscode.Uri.file(key);
+                    vscode.workspace.openTextDocument(uri).then(doc => {
+                        //fix ranges to not include whitespace
+                        for(let i = 0; i < value.length; i++){
+                            let prob = value[i];
+                            let line = doc.lineAt(prob.range.start.line);
+                            prob.range = new vscode.Range(
+                                            new vscode.Position(line.range.start.line, line.firstNonWhitespaceCharacterIndex),
+                                            line.range.end
+                                        );
+                        }
+                        collection.delete(uri);
+                        collection.set(uri , value);
+                    }, reason => {
+                        this._outputChannel.appendLine(reason);
+                    });
                 });
-
-
-            });
+            } else {
+                let uri = vscode.Uri.file(targetPath);
+                collection.delete(uri);
+            }
         });
     }
 
@@ -145,6 +148,3 @@ export class ApexPmd{
         return s.substr(1, s.length-2);
     }
 }
-
-
-


### PR DESCRIPTION
Due to warnings like 'Use Rule name category/apex/bestpractices.xml/ApexUnitTestShouldNotUseSeeAllDataTrue instead of the deprecated Rule name rulesets/apex/apexunit.xml/ApexUnitTestShouldNotUseSeeAllDataTrue. Future versions of PMD will remove support for this deprecated Rule name usage.' I replaced those values.