### PR TITLE
Additional class paths for pr

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Allows you to run [Apex Static Analysis](http://pmd.sourceforge.net/snapshot/pmd
 - `priorityWarnThreshold`: Determines at what priority level 'warnings' will be added. Anything less will be a hint
 - `enableCache`: Creates a cache file for PMD to run faster. Will create a .pmdCache file in your workspace
 - `pmdBinPath` (prev. `pmdPath`) (optional): set to override the default pmd binaries. This should point to the PMD folder which contains folders `lib` and `bin`. Most likely it is called `libexec`.
+- `additionalClassPaths` (optional): set of paths to be appended to classpath. Used to find custom rule definitions. Can be absolute or relative to workspace.
 
 ### Defining your own "Ruleset"
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Allows you to run [Apex Static Analysis](http://pmd.sourceforge.net/snapshot/pmd
 - `priorityWarnThreshold`: Determines at what priority level 'warnings' will be added. Anything less will be a hint
 - `enableCache`: Creates a cache file for PMD to run faster. Will create a .pmdCache file in your workspace
 - `pmdBinPath` (prev. `pmdPath`) (optional): set to override the default pmd binaries. This should point to the PMD folder which contains folders `lib` and `bin`. Most likely it is called `libexec`.
-- `additionalClassPaths` (optional): set of paths to be appended to classpath. Used to find custom rule definitions. Can be absolute or relative to workspace.
+- `additionalClassPaths` (optional): set of paths to be appended to classpath. Used to find jar files containing custom rule definitions. Can be absolute or relative to workspace.
 
 ### Defining your own "Ruleset"
 
@@ -42,9 +42,13 @@ You can also mention the default ruleset in `apexPMD.rulesets`. To do this add `
 
 [Apex Ruleset Reference](https://pmd.github.io/pmd-6.11.0/pmd_rules_apex.html)
 
-NOTE: If you are move alway from the "default result" in an sfdx project, make sure to exclude the `.sfdx` generated classes by keeping this line:
+NOTE: If you move away from the default ruleset in an sfdx project, make sure to exclude the `.sfdx` generated classes by keeping this line:
 
 `<exclude-pattern>.*/.sfdx/.*</exclude-pattern>`
+
+### Using custom rules written in Java
+
+If you want to use your own [custom rules](https://pmd.github.io/latest/pmd_userdocs_extending_writing_pmd_rules.html) from a jar file, then the jar file must be on the classpath. By default, the PMD folder and the workspace root folder are included in the classpath. You can add further folders using the `additionalClassPaths` setting.
 
 ## Legal Stuff
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "apex-pmd",
-    "version": "0.3.1",
+    "version": "0.0.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
     "name": "apex-pmd",
-    "displayName": "Apex PMD",
+    "displayName": "Apex PMD (Sage People)",
     "description": "PMD static analysis for Salesforce Apex",
-    "version": "0.4.1",
-    "publisher": "chuckjonas",
+    "version": "0.1.0",
+    "publisher": "sagepeople",
     "author": {
         "name": "Charlie Jonas",
         "email": "charlie@callawaycloudconsulting.com"

--- a/package.json
+++ b/package.json
@@ -138,7 +138,7 @@
                         "type": "string"
                     },
                     "default": [],
-                    "description": "(Optional) paths to be appended to classpath. Used to find custom rule definitions. Can be absolute or relative to workspace."
+                    "description": "(Optional) paths to be appended to classpath. Used to find jar files containing custom rule definitions. Can be absolute or relative to workspace."
                 }
             }
         },

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
     "name": "apex-pmd",
-    "displayName": "Apex PMD (Sage People)",
+    "displayName": "Apex PMD",
     "description": "PMD static analysis for Salesforce Apex",
-    "version": "0.1.4",
-    "publisher": "sagepeople",
+    "version": "0.4.1",
+    "publisher": "chuckjonas",
     "author": {
         "name": "Charlie Jonas",
         "email": "charlie@callawaycloudconsulting.com"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "apex-pmd",
     "displayName": "Apex PMD (Sage People)",
     "description": "PMD static analysis for Salesforce Apex",
-    "version": "0.1.0",
+    "version": "0.1.4",
     "publisher": "sagepeople",
     "author": {
         "name": "Charlie Jonas",
@@ -131,6 +131,14 @@
                     "type": "boolean",
                     "default": false,
                     "description": "Creates a cache file for PMD to run faster. Will create a .pmdCache file in your workspace"
+                },
+                "apexPMD.additionalClassPaths": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "default": [],
+                    "description": "(Optional) paths to be appended to classpath. Used to find custom rule definitions. Can be absolute or relative to workspace."
                 }
             }
         },

--- a/src/lib/apexPmd.ts
+++ b/src/lib/apexPmd.ts
@@ -140,9 +140,9 @@ export class ApexPmd {
         const targetPathKey = `-d "${targetPath}"`;
         const rulesetsKey = `-R "${rulesetsArg}"`;
 
-        const pmdKeys = `${formatKey} ${cacheKey} ${targetPathKey} ${rulesetsKey}`
+        const pmdKeys = `${formatKey} ${cacheKey} ${targetPathKey} ${rulesetsKey}`;
 
-        const classPath = `${path.join(vscode.workspace.rootPath,'*')};${path.join(this._pmdPath, 'lib', '*')};${this._additionalClassPaths.join(';')}`
+        const classPath = `${path.join(vscode.workspace.rootPath,'*')};${path.join(this._pmdPath, 'lib', '*')};${this._additionalClassPaths.join(';')}`;
 
         const cmd = `java -cp "${classPath}" net.sourceforge.pmd.PMD ${pmdKeys}`;
         if (this._showStdOut) this._outputChannel.appendLine('PMD Command: ' + cmd);

--- a/src/lib/apexPmd.ts
+++ b/src/lib/apexPmd.ts
@@ -29,6 +29,7 @@ export class ApexPmd {
     private _showStdOut: boolean;
     private _showStdErr: boolean;
     private _enableCache: boolean;
+    private _additionalClassPaths: string[];
 
     public constructor(outputChannel: vscode.OutputChannel, config: Config) {
         this._rulesets = this.getValidRulesetPaths(config.rulesets);
@@ -40,6 +41,7 @@ export class ApexPmd {
         this._showStdOut = config.showStdOut;
         this._showStdErr = config.showStdErr;
         this._enableCache = config.enableCache;
+        this._additionalClassPaths = config.additionalClassPaths;
     }
 
     public updateConfiguration(config: Config) {
@@ -51,6 +53,7 @@ export class ApexPmd {
         this._showStdOut = config.showStdOut;
         this._showStdErr = config.showStdErr;
         this._enableCache = config.enableCache;
+        this._additionalClassPaths = config.additionalClassPaths;
     }
 
     public async run(targetPath: string, collection: vscode.DiagnosticCollection, progress?: vscode.Progress<{ message?: string; increment?: number; }>, token?: vscode.CancellationToken): Promise<void> {
@@ -139,7 +142,9 @@ export class ApexPmd {
 
         const pmdKeys = `${formatKey} ${cacheKey} ${targetPathKey} ${rulesetsKey}`
 
-        const cmd = `java -cp "${vscode.workspace.rootPath}/*;${path.join(this._pmdPath, 'lib', '*')}" net.sourceforge.pmd.PMD ${pmdKeys}`;
+        const classPath = `${path.join(vscode.workspace.rootPath,'*')};${path.join(this._pmdPath, 'lib', '*')};${this._additionalClassPaths.join(';')}`
+
+        const cmd = `java -cp ${classPath} net.sourceforge.pmd.PMD ${pmdKeys}`;
         if (this._showStdOut) this._outputChannel.appendLine('PMD Command: ' + cmd);
 
         let pmdCmd = ChildProcess.exec(cmd);

--- a/src/lib/apexPmd.ts
+++ b/src/lib/apexPmd.ts
@@ -139,7 +139,7 @@ export class ApexPmd {
 
         const pmdKeys = `${formatKey} ${cacheKey} ${targetPathKey} ${rulesetsKey}`
 
-        const cmd = `java -cp "${path.join(this._pmdPath, 'lib', '*')}" net.sourceforge.pmd.PMD ${pmdKeys}`;
+        const cmd = `java -cp "${vscode.workspace.rootPath}/*;${path.join(this._pmdPath, 'lib', '*')}" net.sourceforge.pmd.PMD ${pmdKeys}`;
         if (this._showStdOut) this._outputChannel.appendLine('PMD Command: ' + cmd);
 
         let pmdCmd = ChildProcess.exec(cmd);

--- a/src/lib/apexPmd.ts
+++ b/src/lib/apexPmd.ts
@@ -144,7 +144,7 @@ export class ApexPmd {
 
         const classPath = `${path.join(vscode.workspace.rootPath,'*')};${path.join(this._pmdPath, 'lib', '*')};${this._additionalClassPaths.join(';')}`
 
-        const cmd = `java -cp ${classPath} net.sourceforge.pmd.PMD ${pmdKeys}`;
+        const cmd = `java -cp "${classPath}" net.sourceforge.pmd.PMD ${pmdKeys}`;
         if (this._showStdOut) this._outputChannel.appendLine('PMD Command: ' + cmd);
 
         let pmdCmd = ChildProcess.exec(cmd);

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -14,6 +14,7 @@ export class Config{
     public showStdOut: boolean;
     public showStdErr: boolean;
     public enableCache: boolean;
+    public additionalClassPaths: string[];
 
     private _ctx: vscode.ExtensionContext;
 
@@ -40,6 +41,7 @@ export class Config{
         this.showStdOut = config.get('showStdOut') as boolean;
         this.showStdErr = config.get('showStdErr') as boolean;
         this.enableCache = config.get('enableCache') as boolean;
+        this.additionalClassPaths = config.get('additionalClassPaths') as string[];
         this.resolvePaths();
     }
 
@@ -73,6 +75,20 @@ export class Config{
 
         if (!this.pmdBinPath) {
             this.pmdBinPath = this._ctx.asAbsolutePath(path.join('bin', 'pmd'));
+        }
+
+        if (!this.additionalClassPaths) {
+            this.additionalClassPaths = [];
+        }
+
+        if (this.additionalClassPaths.length) {
+            this.additionalClassPaths = this.additionalClassPaths.map((unresolvedPath) => {
+                let resolvedPath = unresolvedPath
+                if (!path.isAbsolute(unresolvedPath) && vscode.workspace.rootPath) {
+                    resolvedPath = path.join(vscode.workspace.rootPath, unresolvedPath);
+                }
+                return resolvedPath        
+            })
         }
     }
 }

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -83,12 +83,12 @@ export class Config{
 
         if (this.additionalClassPaths.length) {
             this.additionalClassPaths = this.additionalClassPaths.map((unresolvedPath) => {
-                let resolvedPath = unresolvedPath
+                let resolvedPath = unresolvedPath;
                 if (!path.isAbsolute(unresolvedPath) && vscode.workspace.rootPath) {
                     resolvedPath = path.join(vscode.workspace.rootPath, unresolvedPath);
                 }
-                return resolvedPath        
-            })
+                return resolvedPath;
+            });
         }
     }
 }


### PR DESCRIPTION
We had a need to write a custom PMD rule in java, and wanted to put our JAR alongside our source so CI can get it easily.

These changes add the workspace root to the classpath, and also adds a setting to be able to configure additional paths on the classpath, so the JAR can be found and the rule used.