### PR TITLE
Add config to control buffer size to resolve #38

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Allows you to run [Apex Static Analysis](http://pmd.sourceforge.net/snapshot/pmd
 - `enableCache`: Creates a cache file for PMD to run faster. Will create a .pmdCache file in your workspace
 - `pmdBinPath` (prev. `pmdPath`) (optional): set to override the default pmd binaries. This should point to the PMD folder which contains folders `lib` and `bin`. Most likely it is called `libexec`.
 - `additionalClassPaths` (optional): set of paths to be appended to classpath. Used to find jar files containing custom rule definitions. Can be absolute or relative to workspace.
+- `commandBufferSize` Size of buffer used to collect PMD command output (MB), may need to be increased for very large projects
 
 ### Defining your own "Ruleset"
 

--- a/package.json
+++ b/package.json
@@ -139,6 +139,11 @@
                     },
                     "default": [],
                     "description": "(Optional) paths to be appended to classpath. Used to find jar files containing custom rule definitions. Can be absolute or relative to workspace."
+                },
+                "apexPMD.commandBufferSize": {
+                    "type": "number",
+                    "default": "64",
+                    "description": "Size of buffer used to collect PMD command output (MB), may need to be increased for very large projects"
                 }
             }
         },

--- a/src/lib/apexPmd.ts
+++ b/src/lib/apexPmd.ts
@@ -37,6 +37,7 @@ export class ApexPmd {
     private _enableCache: boolean;
     private _additionalClassPaths: string[];
     private _workspaceRootPath: string;
+    private _commandBufferSize: number;
 
     public constructor(outputChannel: vscode.OutputChannel, config: Config) {
         this._rulesets = this.getValidRulesetPaths(config.rulesets);
@@ -50,6 +51,7 @@ export class ApexPmd {
         this._showStdErr = config.showStdErr;
         this._enableCache = config.enableCache;
         this._additionalClassPaths = config.additionalClassPaths;
+        this._commandBufferSize = config.commandBufferSize;
     }
 
     public updateConfiguration(config: Config) {
@@ -162,7 +164,8 @@ export class ApexPmd {
 
         if (this._showStdOut) this._outputChannel.appendLine('PMD Command: ' + cmd);
 
-        let pmdCmd = ChildProcess.exec(cmd);
+        let pmdCmd = ChildProcess.exec(cmd, 
+            {maxBuffer: Math.max(this._commandBufferSize, 1) * 1024 * 1024});
 
         token && token.onCancellationRequested(() => {
             pmdCmd.kill();

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -16,6 +16,7 @@ export class Config {
     public showStdErr: boolean;
     public enableCache: boolean;
     public additionalClassPaths: string[];
+    public commandBufferSize: number;
 
     private _ctx: vscode.ExtensionContext;
 
@@ -44,6 +45,7 @@ export class Config {
         this.showStdErr = config.get('showStdErr') as boolean;
         this.enableCache = config.get('enableCache') as boolean;
         this.additionalClassPaths = config.get('additionalClassPaths') as string[];
+        this.commandBufferSize = config.get('commandBufferSize') as number;
         this.resolvePaths();
     }
 


### PR DESCRIPTION
This stops the 143 error on my projects, the 64MB default size might be a bit overkill but wanted to give plenty of headroom. An alternative approach to avoid having this setting would be to use ChildProcess.spawn but that would require identifying the PATH to java.