### PR TITLE
Remove onDidCloseTextDocument handling to resolve #56

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -86,10 +86,6 @@ export function activate(context: vscode.ExtensionContext) {
             AppStatus.getInstance().hide();
         }
     }));
-
-    vscode.workspace.onDidCloseTextDocument((textDocument) => {
-        collection.delete(textDocument.uri);
-    });
 }
 
 export function deactivate() { }


### PR DESCRIPTION
This is just your simpler approach to fixing this, works great for me. Can always be improved again if there is a preference for it to auto-clear diag for closed files.  