### PR TITLE
Update cache option to new PMD format

### DIFF
--- a/src/lib/apexPmd.ts
+++ b/src/lib/apexPmd.ts
@@ -127,7 +127,7 @@ export class ApexPmd {
     const cachePath = `${workspaceRootPath}/.pmdCache`;
     const rulesetsArg = this.rulesets.join(',');
 
-    const cacheKey = enableCache ? `-cache "${cachePath}"` : '-no-cache';
+    const cacheKey = enableCache ? `--cache "${cachePath}"` : '--no-cache';
     const formatKey = `-f csv`;
     const targetPathKey = `-d "${targetPath}"`;
     const rulesetsKey = `-R "${rulesetsArg}"`;


### PR DESCRIPTION
https://pmd.github.io/latest/pmd_userdocs_cli_reference.html shows a double-dash, and when I run ApexPMD now, it says that the option -cache is deprecated. It works, but we can avoid the warning by updating to a double-dash

stderr:Jan 07, 2022 10:39:21 AM net.sourceforge.pmd.PMD runPmd
WARNING: Some deprecated options were used on the command-line, including -cache

stderr:Jan 07, 2022 10:39:21 AM net.sourceforge.pmd.PMD runPmd
WARNING: Consider replacing it with --cache

stderr:Jan 07, 2022 10:39:21 AM net.sourceforge.pmd.cache.FileAnalysisCache loadFromFile
INFO: Analysis cache loaded

stderr:Jan 07, 2022 10:39:22 AM net.sourceforge.pmd.cache.FileAnalysisCache persist
INFO: Analysis cache updated