### PR TITLE
Add GitHub Actions workflow for automated release

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -35,19 +35,16 @@ jobs:
       shell: bash
       run: |
         # configure git
-        # see https://github.com/orgs/community/discussions/26560 and https://api.github.com/users/github-actions[bot]
-        git config --local user.name "github-actions[bot]"
-        git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
+        git config --local user.name "${GITHUB_ACTOR}"
+        git config --local user.email "${GITHUB_ACTOR}@users.noreply.github.com"
 
-        RELEASE_VERSION="${{ inputs.releaseVersion }}"
-        NEXT_VERSION="${{ inputs.nextVersion }}"
         RELEASE_DATE=$(date +%Y-%m-%d)
 
         npx json --in-place -f package.json -e "this.version=\"${RELEASE_VERSION}\""
         npm install
 
         sed -i "s/^## \[Unreleased\]/## [${RELEASE_VERSION}] - ${RELEASE_DATE}/" CHANGELOG.md
-        sed -i "s/^\(\*\*Full Changelog\*\*: https:\/\/github.com\/ChuckJonas\/vscode-apex-pmd\/compare\/v[0-9]\+\.[0-9]\+\.[0-9]\+\.\.\.\)HEAD$/\1v${RELEASE_VERSION}/" CHANGELOG.md
+        sed -i "s;^\(\*\*Full Changelog\*\*: https://github.com/ChuckJonas/vscode-apex-pmd/compare/v[0-9]\+\.[0-9]\+\.[0-9]\+\.\.\.\)HEAD$;\1v${RELEASE_VERSION};" CHANGELOG.md
 
         git add --update
         git commit -m "v${RELEASE_VERSION}"
@@ -78,11 +75,16 @@ jobs:
         git commit -m "Prepare next development version v${NEXT_VERSION}"
 
         git push origin --atomic --follow-tags --tags HEAD:master
+      env:
+        RELEASE_VERSION: ${{ inputs.releaseVersion }}
+        NEXT_VERSION: ${{ inputs.nextVersion }}
     - name: Build from tag v${{ inputs.releaseVersion }}
       shell: bash
       run: |
-        git checkout "v${{ inputs.releaseVersion }}"
+        git checkout "v${RELEASE_VERSION}"
         npm run vscode:package
+      env:
+        RELEASE_VERSION: ${{ inputs.releaseVersion }}
     - name: Prepare release notes
       id: release_notes
       shell: bash
@@ -93,9 +95,9 @@ jobs:
         RELEASE_TITLE="${RELEASE_VERSION} - ${RELEASE_DATE}"
 
         {
-          echo 'body<<EOF'
+          echo 'body<<EOF_RELEASE_NOTES_EOF'
           echo "${RELEASE_NOTES}"
-          echo EOF
+          echo EOF_RELEASE_NOTES_EOF
         } >> $GITHUB_OUTPUT
         echo "title=${RELEASE_TITLE}" >> $GITHUB_OUTPUT
     - name: Create a draft release

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -1,0 +1,106 @@
+name: Prepare Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      releaseVersion:
+        description: 'The version of the release, e.g. 0.6.2'
+        required: true
+        type: string
+      nextVersion:
+        description: 'The version of the next release, e.g. 0.6.3'
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        ref: master
+        persist-credentials: true
+    - uses: actions/setup-node@v3
+      with:
+        node-version: 18
+        cache: 'npm'
+    - name: Install npm dependencies
+      run: npm ci
+    - name: Set release version, tag, prepare next development version and push
+      shell: bash
+      run: |
+        # configure git
+        # see https://github.com/orgs/community/discussions/26560 and https://api.github.com/users/github-actions[bot]
+        git config --local user.name "github-actions[bot]"
+        git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+        RELEASE_VERSION="${{ inputs.releaseVersion }}"
+        NEXT_VERSION="${{ inputs.nextVersion }}"
+        RELEASE_DATE=$(date +%Y-%m-%d)
+
+        npx json --in-place -f package.json -e "this.version=\"${RELEASE_VERSION}\""
+        npm install
+
+        sed -i "s/^## \[Unreleased\]/## [${RELEASE_VERSION}] - ${RELEASE_DATE}/" CHANGELOG.md
+        sed -i "s/^\(\*\*Full Changelog\*\*: https:\/\/github.com\/ChuckJonas\/vscode-apex-pmd\/compare\/v[0-9]\+\.[0-9]\+\.[0-9]\+\.\.\.\)HEAD$/\1v${RELEASE_VERSION}/" CHANGELOG.md
+
+        git add --update
+        git commit -m "v${RELEASE_VERSION}"
+        git tag "v${RELEASE_VERSION}"
+
+        npx json --in-place -f package.json -e "this.version=\"${NEXT_VERSION}-snapshot.0\""
+        npm install
+
+        START=$(grep -n -E "^## " CHANGELOG.md | head -1 | cut -d ':' -f 1)
+        START=$((START - 1))
+        INTRO=$(head -n "$START" CHANGELOG.md)
+        REST=$(tail -n "+$START" CHANGELOG.md)
+        echo "${INTRO}
+
+        ## [Unreleased]
+
+        ### Added
+        ### Changed
+        ### Deprecated
+        ### Removed
+        ### Fixed
+        ### New Contributors
+
+        **Full Changelog**: https://github.com/ChuckJonas/vscode-apex-pmd/compare/v${RELEASE_VERSION}...HEAD
+        ${REST}" > CHANGELOG.md
+
+        git add --update
+        git commit -m "Prepare next development version v${NEXT_VERSION}"
+
+        git push origin --atomic --follow-tags --tags HEAD:master
+    - name: Build from tag v${{ inputs.releaseVersion }}
+      shell: bash
+      run: |
+        git checkout "v${{ inputs.releaseVersion }}"
+        npm run vscode:package
+    - name: Prepare release notes
+      id: release_notes
+      shell: bash
+      run: |
+        START=$(grep -n -E "^## " CHANGELOG.md | head -2 | tail -1 | cut -d ':' -f 1)
+        END=$(grep -n -E "^## " CHANGELOG.md | head -3 | tail -1 | cut -d ':' -f 1)
+        RELEASE_NOTES=$(tail -n +$((START + 1)) CHANGELOG.md | head -n $((END - START - 1)))
+        RELEASE_TITLE="${RELEASE_VERSION} - ${RELEASE_DATE}"
+
+        {
+          echo 'body<<EOF'
+          echo "${RELEASE_NOTES}"
+          echo EOF
+        } >> $GITHUB_OUTPUT
+        echo "title=${RELEASE_TITLE}" >> $GITHUB_OUTPUT
+    - name: Create a draft release
+      uses: softprops/action-gh-release@v1
+      with:
+        tag_name: v${{ inputs.releaseVersion }}
+        name: ${{ steps.release_notes.title }}
+        body: ${{ steps.release_notes.body }}
+        files: apex-pmd-${{ inputs.releaseVersion }}.vsix
+        draft: true

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -1,5 +1,7 @@
 name: Prepare Release
 
+# See RELEASING.md
+
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,0 +1,28 @@
+name: Publish Release
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-node@v3
+      with:
+        node-version: 18
+        cache: 'npm'
+    - name: Install npm dependencies
+      run: npm ci
+    - name: Download release asset and publish to Visual Studio Code Marketplace
+      shell: bash
+      run: |
+        curl --location --remote-name ${{ github.event.release.assets[0].browser_download_url }}
+        ls -lh
+        npx vsce publish --packagePath apex-pmd-*.vsix
+      env:
+        VSCE_PAT: ${{ secrets.VSCE_PAT }}

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,5 +1,7 @@
 name: Publish Release
 
+# See RELEASING.md
+
 on:
   release:
     types: [published]

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -23,8 +23,9 @@ jobs:
     - name: Download release asset and publish to Visual Studio Code Marketplace
       shell: bash
       run: |
-        curl --location --remote-name ${{ github.event.release.assets[0].browser_download_url }}
+        curl --location --remote-name ${VSIX_URL}
         ls -lh
         npx vsce publish --packagePath apex-pmd-*.vsix
       env:
         VSCE_PAT: ${{ secrets.VSCE_PAT }}
+        VSIX_URL: ${{ github.event.release.assets[0].browser_download_url }}

--- a/.github/workflows/update-pmd.yml
+++ b/.github/workflows/update-pmd.yml
@@ -44,7 +44,7 @@ jobs:
         {
           echo "$BEFORE"
           echo
-          echo "* Upgraded to PMD ${PMD_VERSION}"
+          echo "- Upgraded to PMD ${PMD_VERSION}"
           echo "$AFTER"
         } > CHANGELOG.md
       env:

--- a/.github/workflows/update-pmd.yml
+++ b/.github/workflows/update-pmd.yml
@@ -1,0 +1,49 @@
+name: Update PMD
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        ref: master
+        persist-credentials: true
+    - uses: actions/setup-node@v3
+      with:
+        node-version: 18
+        cache: 'npm'
+    - name: Install npm dependencies
+      run: npm ci
+    - name: Update PMD
+      id: pmd
+      shell: bash
+      run: |
+        VERSION=$(curl -s https://api.github.com/repos/pmd/pmd/releases/latest | jq --raw-output ".tag_name" | sed 's:.*/::')
+        echo "version=$VERSION" >> $GITHUB_OUTPUT
+        cd pmd-packager
+        ./upgrade.sh "$VERSION"
+    - name: Commit and Push
+      shell: bash
+      run: |
+        # configure git
+        # see https://github.com/orgs/community/discussions/26560 and https://api.github.com/users/github-actions[bot]
+        git config --local user.name "github-actions[bot]"
+        git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
+        git add -A
+        git commit -m "Update PMD ${{ steps.pmd.version }}"
+    - name: Run Tests
+      shell: bash
+      run: npm test
+    - name: Push
+      shell: bash
+      run: |
+        git push origin
+
+# TODO: Update CHANGELOG.md
+# TODO: Create a PR instead?

--- a/.github/workflows/update-pmd.yml
+++ b/.github/workflows/update-pmd.yml
@@ -5,6 +5,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
   build:
@@ -24,26 +25,30 @@ jobs:
       id: pmd
       shell: bash
       run: |
-        VERSION=$(curl -s https://api.github.com/repos/pmd/pmd/releases/latest | jq --raw-output ".tag_name" | sed 's:.*/::')
-        echo "version=$VERSION" >> $GITHUB_OUTPUT
+        PMD_VERSION=$(curl -s https://api.github.com/repos/pmd/pmd/releases/latest | jq --raw-output ".tag_name" | sed 's:.*/::')
+        echo "version=$PMD_VERSION" >> $GITHUB_OUTPUT
         cd pmd-packager
-        ./upgrade.sh "$VERSION"
-    - name: Commit and Push
+        ./upgrade.sh "$PMD_VERSION"
+    - name: Update CHANGELOG
       shell: bash
       run: |
-        # configure git
-        # see https://github.com/orgs/community/discussions/26560 and https://api.github.com/users/github-actions[bot]
-        git config --local user.name "github-actions[bot]"
-        git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
-        git add -A
-        git commit -m "Update PMD ${{ steps.pmd.version }}"
+        LINE=$(grep -n "^## \[Unreleased\]" CHANGELOG.md | cut -d ':' -f 1)
+        BEFORE=$(head -n $LINE CHANGELOG.md)
+        AFTER=$(tail -n +$((LINE + 1)) CHANGELOG.md)
+        {
+          echo "$BEFORE"
+          echo
+          echo "* Upgraded to PMD ${PMD_VERSION}"
+          echo "$AFTER"
+        } > CHANGELOG.md
+      env:
+        PMD_VERSION: ${{ steps.pmd.version }}
     - name: Run Tests
       shell: bash
       run: npm test
-    - name: Push
-      shell: bash
-      run: |
-        git push origin
-
-# TODO: Update CHANGELOG.md
-# TODO: Create a PR instead?
+    - name: Create Pull Request
+      uses: peter-evans/create-pull-request@v5
+      with:
+        title: Upgrade to PMD ${{ steps.pmd.version }}
+        commit-message: Upgrade to PMD ${{ steps.pmd.version }}
+        branch: upgrade-pmd-${{ steps.pmd.version }}

--- a/.github/workflows/update-pmd.yml
+++ b/.github/workflows/update-pmd.yml
@@ -1,5 +1,11 @@
 name: Update PMD
 
+#
+# - Updates PMD to the latest released version of PMD.
+# - Runs the tests
+# - Creates a new pull request for the changes
+#
+
 on:
   workflow_dispatch:
 
@@ -21,7 +27,7 @@ jobs:
         cache: 'npm'
     - name: Install npm dependencies
       run: npm ci
-    - name: Update PMD
+    - name: Upgrade PMD
       id: pmd
       shell: bash
       run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+
+- Add GitHub Actions workflow for automated release by @adangel in [#153](https://github.com/ChuckJonas/vscode-apex-pmd/pull/153)
+- CI/CD and releasing [#95](https://github.com/ChuckJonas/vscode-apex-pmd/issues/95)
+
 ### Changed
 ### Deprecated
 ### Removed

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -84,7 +84,7 @@ Steps to do when releasing a new version of this extension. These steps can be a
     ```
 
 ## Perform the release
-1. Push the changes and the tag. Wait for Github Actions to build the extension. Download the extension from Github Actions workflow.
+1. Push the changes and the tag. Wait for Github Actions to build the extension. Download the extension from [Github Actions workflow](https://github.com/ChuckJonas/vscode-apex-pmd/actions).
     ```shell
     git push origin master
     git push origin tag "v${RELEASE_VERSION}
@@ -94,8 +94,8 @@ Steps to do when releasing a new version of this extension. These steps can be a
     - Manual: Go to <https://github.com/ChuckJonas/vscode-apex-pmd/releases/new>
     - When automated, we can use [softprops/action-gh-release](https://github.com/softprops/action-gh-release)
     ```shell
-    START=$(grep -n -E "^## " CHANGELOG.md | head -1 | cut -d ':' -f 1)
-    END=$(grep -n -E "^## " CHANGELOG.md | head -2 | tail -1 | cut -d ':' -f 1)
+    START=$(grep -n -E "^## " CHANGELOG.md | head -2 | tail -1 | cut -d ':' -f 1)
+    END=$(grep -n -E "^## " CHANGELOG.md | head -3 | tail -1 | cut -d ':' -f 1)
     RELEASE_NOTES=$(tail -n +$((START + 1)) CHANGELOG.md | head -n $((END - START - 1)))
     RELEASE_TITLE="${RELEASE_VERSION} - ${RELEASE_DATE}"
     ```

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,103 @@
+# Releasing
+
+Steps to do when releasing a new version of this extension. These steps can be automated.
+
+## Preparation
+
+0. Review the current `CHANGELOG.md`: Is it complete? Are there (breaking) changes, that would require to bump the
+    major version?
+
+1. Define the version that shall be released. This is referenced as `RELEASE_VERSION` later on.
+    ```shell
+    RELEASE_VERSION=x.y.z
+    NEXT_VERSION=x.y.z+1
+    RELEASE_DATE=$(date +%Y-%m-%d)
+    ```
+2. Update `package.json` with `RELEASE_VERSION`, run `npm install` in order to update `package-lock.json`:
+
+    ```shell
+    npx json --in-place -f package.json -e "this.version=\"${RELEASE_VERSION}\""
+    npm install
+    ```
+3. Update `CHANGELOG.md` - replace `[Unreleased]` with `[RELEASE_VERSION] - YYYY-MM-DD`.
+
+    ```shell
+    sed -i "s/^## \[Unreleased\]/## [${RELEASE_VERSION}] - ${RELEASE_DATE}/" CHANGELOG.md
+    sed -i "s/^\(\*\*Full Changelog\*\*: https:\/\/github.com\/ChuckJonas\/vscode-apex-pmd\/compare\/v[0-9]\+\.[0-9]\+\.[0-9]\+\.\.\.\)HEAD$/\1v${RELEASE_VERSION}/" CHANGELOG.md
+    ```
+4. Commit the changes to master branch and create a new tag. The tag is `RELEASE_VERSION` prefixed with `v`.
+    
+    ```shell
+    git add --update
+    git commit -m "v${RELEASE_VERSION}"
+    git tag "v${RELEASE_VERSION}"
+    ```
+5. Update `package.json` with the next development version, e.g. if RELEASE_VERSION is 0.6.2, then
+    the next version is 0.6.3-snapshot.0. Run `npm install`.
+    
+    ```shell
+    npx json --in-place -f package.json -e "this.version=\"${NEXT_VERSION}-snapshot.0\""
+    npm install
+    ```
+6. Update `CHANGELOG.md` and add a new `[Unreleased]` section:
+
+    ```
+    ## [Unreleased]
+
+    ### Added
+    ### Changed
+    ### Deprecated
+    ### Removed
+    ### Fixed
+    ### New Contributors
+
+    **Full Changelog**: https://github.com/ChuckJonas/vscode-apex-pmd/compare/v${RELEASE_VERSION}...HEAD
+    ```
+
+    As a script:
+
+    ```shell
+    START=$(grep -n -E "^## " CHANGELOG.md | head -1 | cut -d ':' -f 1)
+    START=$((START - 1))
+    INTRO=$(head -n "$START" CHANGELOG.md)
+    REST=$(tail -n "+$START" CHANGELOG.md)
+    echo "${INTRO}
+
+    ## [Unreleased]
+
+    ### Added
+    ### Changed
+    ### Deprecated
+    ### Removed
+    ### Fixed
+    ### New Contributors
+
+    **Full Changelog**: https://github.com/ChuckJonas/vscode-apex-pmd/compare/v${RELEASE_VERSION}...HEAD
+    ${REST}" > CHANGELOG.md
+    ```
+
+7. Commit the changes to master branch.
+
+    ```shell
+    git add --update
+    git commit -m "Prepare next development version v${NEXT_VERSION}"
+    ```
+
+## Perform the release
+1. Push the changes and the tag. Wait for Github Actions to build the extension. Download the extension from Github Actions workflow.
+    ```shell
+    git push origin master
+    git push origin tag "v${RELEASE_VERSION}
+    ```
+2. Create a new Release on github based on the tag. Copy the release notes from `CHANGELOG.md`, upload the
+    extension package `apex-pmd-RELEASE_VERSION.vsix`.
+    - Manual: Go to <https://github.com/ChuckJonas/vscode-apex-pmd/releases/new>
+    - When automated, we can use [softprops/action-gh-release](https://github.com/softprops/action-gh-release)
+3. Publish the extension in Visual Studio Code Marketplace
+    - Manual: Go to <https://marketplace.visualstudio.com/manage/publishers/chuckjonas>
+    - Using a script:
+    ```shell
+    export VSCE_PAT=....
+    npx vsce login
+    npx vsce publish --packagePath apex-pmd-${RELEASE_VERSION}.vsix
+    ```

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,45 +1,85 @@
 # Releasing
 
-Steps to do when releasing a new version of this extension. These steps can be automated.
+Steps to do when releasing a new version of this extension. These steps can either be executed
+manually or can be triggered via GitHub Actions
 
-## Preparation
+## Via GitHub Actions
 
-0. Review the current `CHANGELOG.md`: Is it complete? Are there (breaking) changes, that would require to bump the
+1. Review the current `CHANGELOG.md`: Is it complete? Are there (breaking) changes, that would require to bump the
     major version?
 
-1. Define the version that shall be released. This is referenced as `RELEASE_VERSION` later on.
+2. Trigger the workflow [prepare-release](https://github.com/ChuckJonas/vscode-apex-pmd/actions/workflows/prepare-release.yml)
+    in the GitHub Web UI. Provide a `releaseVersion` and a `nextVersion`
+
+    The workflow will
+    - Update the versions and changelog
+    - Create a tag
+    - Create a draft release
+
+3. Once the prepare-release workflow is finished, you should see a new draft release under [releases](https://github.com/ChuckJonas/vscode-apex-pmd/releases)
+
+    - verify the contents of the release notes
+    - verify that a vsix-file is in the release assets
+    - (optional) download the vsix-file and install it locally and test the plugin. This is optional, since we have
+      some automated tests.
+    - If everything looks right, publish this release as the new latest release. This will trigger
+      the [publish-release](https://github.com/ChuckJonas/vscode-apex-pmd/actions/workflows/publish-release.yml) which
+      will publish the release to Visual Studio Code Marketplace.
+
+4. Once the publish-release workflow is finished, verify, that the new version is available in the marketplace
+    (this might take a few minutes): <https://marketplace.visualstudio.com/items?itemName=chuckjonas.apex-pmd>
+
+
+### Prerequisites
+
+The `publish-release` workflow needs a PAT for uploading the release to Visual Studio Marketplace. The PAT needs
+to be provided as a workflow secret named `VSCE_PAT`. For generating this PAT, see
+<https://code.visualstudio.com/api/working-with-extensions/publishing-extension#get-a-personal-access-token>
+
+`VSCE_PAT` needs to be configured as a repository secret under
+<https://github.com/ChuckJonas/vscode-apex-pmd/settings/secrets/actions>
+
+
+## Manual release
+
+### Preparation
+
+1. Review the current `CHANGELOG.md`: Is it complete? Are there (breaking) changes, that would require to bump the
+    major version?
+
+2. Define the version that shall be released. This is referenced as `RELEASE_VERSION` later on.
     ```shell
     RELEASE_VERSION=x.y.z
     NEXT_VERSION=x.y.z+1
     RELEASE_DATE=$(date +%Y-%m-%d)
     ```
-2. Update `package.json` with `RELEASE_VERSION`, run `npm install` in order to update `package-lock.json`:
+3. Update `package.json` with `RELEASE_VERSION`, run `npm install` in order to update `package-lock.json`:
 
     ```shell
     npx json --in-place -f package.json -e "this.version=\"${RELEASE_VERSION}\""
     npm install
     ```
-3. Update `CHANGELOG.md` - replace `[Unreleased]` with `[RELEASE_VERSION] - YYYY-MM-DD`.
+4. Update `CHANGELOG.md` - replace `[Unreleased]` with `[RELEASE_VERSION] - YYYY-MM-DD`.
 
     ```shell
     sed -i "s/^## \[Unreleased\]/## [${RELEASE_VERSION}] - ${RELEASE_DATE}/" CHANGELOG.md
     sed -i "s/^\(\*\*Full Changelog\*\*: https:\/\/github.com\/ChuckJonas\/vscode-apex-pmd\/compare\/v[0-9]\+\.[0-9]\+\.[0-9]\+\.\.\.\)HEAD$/\1v${RELEASE_VERSION}/" CHANGELOG.md
     ```
-4. Commit the changes to master branch and create a new tag. The tag is `RELEASE_VERSION` prefixed with `v`.
+5. Commit the changes to master branch and create a new tag. The tag is `RELEASE_VERSION` prefixed with `v`.
     
     ```shell
     git add --update
     git commit -m "v${RELEASE_VERSION}"
     git tag "v${RELEASE_VERSION}"
     ```
-5. Update `package.json` with the next development version, e.g. if RELEASE_VERSION is 0.6.2, then
+6. Update `package.json` with the next development version, e.g. if RELEASE_VERSION is 0.6.2, then
     the next version is 0.6.3-snapshot.0. Run `npm install`.
     
     ```shell
     npx json --in-place -f package.json -e "this.version=\"${NEXT_VERSION}-snapshot.0\""
     npm install
     ```
-6. Update `CHANGELOG.md` and add a new `[Unreleased]` section:
+7. Update `CHANGELOG.md` and add a new `[Unreleased]` section:
 
     ```
     ## [Unreleased]
@@ -76,19 +116,21 @@ Steps to do when releasing a new version of this extension. These steps can be a
     ${REST}" > CHANGELOG.md
     ```
 
-7. Commit the changes to master branch.
+8. Commit the changes to master branch.
 
     ```shell
     git add --update
     git commit -m "Prepare next development version v${NEXT_VERSION}"
     ```
 
-## Perform the release
+### Perform the release
+
 1. Push the changes and the tag. Wait for Github Actions to build the extension. Download the extension from [Github Actions workflow](https://github.com/ChuckJonas/vscode-apex-pmd/actions).
     ```shell
     git push origin master
     git push origin tag "v${RELEASE_VERSION}"
     ```
+
 2. Create a new Release on github based on the tag. Copy the release notes from `CHANGELOG.md`, upload the
     extension package `apex-pmd-RELEASE_VERSION.vsix`.
     - Manual: Go to <https://github.com/ChuckJonas/vscode-apex-pmd/releases/new>
@@ -99,6 +141,7 @@ Steps to do when releasing a new version of this extension. These steps can be a
     RELEASE_NOTES=$(tail -n +$((START + 1)) CHANGELOG.md | head -n $((END - START - 1)))
     RELEASE_TITLE="${RELEASE_VERSION} - ${RELEASE_DATE}"
     ```
+
 3. Publish the extension in Visual Studio Code Marketplace
     - Manual: Go to <https://marketplace.visualstudio.com/manage/publishers/chuckjonas>
     - Using a script:

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -93,6 +93,12 @@ Steps to do when releasing a new version of this extension. These steps can be a
     extension package `apex-pmd-RELEASE_VERSION.vsix`.
     - Manual: Go to <https://github.com/ChuckJonas/vscode-apex-pmd/releases/new>
     - When automated, we can use [softprops/action-gh-release](https://github.com/softprops/action-gh-release)
+    ```shell
+    START=$(grep -n -E "^## " CHANGELOG.md | head -1 | cut -d ':' -f 1)
+    END=$(grep -n -E "^## " CHANGELOG.md | head -2 | tail -1 | cut -d ':' -f 1)
+    RELEASE_NOTES=$(tail -n +$((START + 1)) CHANGELOG.md | head -n $((END - START - 1)))
+    RELEASE_TITLE="${RELEASE_VERSION} - ${RELEASE_DATE}"
+    ```
 3. Publish the extension in Visual Studio Code Marketplace
     - Manual: Go to <https://marketplace.visualstudio.com/manage/publishers/chuckjonas>
     - Using a script:

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -98,6 +98,6 @@ Steps to do when releasing a new version of this extension. These steps can be a
     - Using a script:
     ```shell
     export VSCE_PAT=....
-    npx vsce login
+    #npx vsce login chuckjonas
     npx vsce publish --packagePath apex-pmd-${RELEASE_VERSION}.vsix
     ```

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -87,7 +87,7 @@ Steps to do when releasing a new version of this extension. These steps can be a
 1. Push the changes and the tag. Wait for Github Actions to build the extension. Download the extension from [Github Actions workflow](https://github.com/ChuckJonas/vscode-apex-pmd/actions).
     ```shell
     git push origin master
-    git push origin tag "v${RELEASE_VERSION}
+    git push origin tag "v${RELEASE_VERSION}"
     ```
 2. Create a new Release on github based on the tag. Copy the release notes from `CHANGELOG.md`, upload the
     extension package `apex-pmd-RELEASE_VERSION.vsix`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "eslint": "^6.8.0",
         "eslint-config-prettier": "^6.11.0",
         "eslint-plugin-prettier": "^3.1.3",
+        "json": "^11.0.0",
         "mocha": "^10.2.0",
         "prettier": "^2.0.5",
         "ts-loader": "^8.0.2",
@@ -2188,6 +2189,18 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/json": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/json/-/json-11.0.0.tgz",
+      "integrity": "sha512-N/ITv3Yw9Za8cGxuQqSqrq6RHnlaHWZkAFavcfpH/R52522c26EbihMxnY7A1chxfXJ4d+cEFIsyTgfi9GihrA==",
+      "dev": true,
+      "bin": {
+        "json": "lib/json.js"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/json-parse-even-better-errors": {

--- a/package.json
+++ b/package.json
@@ -196,7 +196,8 @@
     "typescript": "^3.8.3",
     "@vscode/test-electron": "^2.3.4",
     "webpack": "^5.88.2",
-    "webpack-cli": "^5.1.4"
+    "webpack-cli": "^5.1.4",
+    "json": "^11.0.0"
   },
   "dependencies": {
     "csv-parse": "^4.8.5",

--- a/pmd-packager/upgrade.sh
+++ b/pmd-packager/upgrade.sh
@@ -1,4 +1,7 @@
-VERSION=$(curl -s https://api.github.com/repos/pmd/pmd/releases/latest | jq --raw-output ".tag_name" | sed 's:.*/::')
+VERSION=$1
+if [ -z "$VERSION" ]; then
+    VERSION=$(curl -s https://api.github.com/repos/pmd/pmd/releases/latest | jq --raw-output ".tag_name" | sed 's:.*/::')
+fi
 echo $VERSION
 ./mvnw clean package -Dpmd.dist.bin.baseDirectory=pmd -Dpmd.version=$VERSION
 rm -rf ../bin/pmd/*


### PR DESCRIPTION
This documents the release process and provides script snippets, that can be executed manually (when GitHub Actions isnt' available).

Additionally, three GitHub Actions workflows are provided:

1. prepare-release: Can be triggered manually with providing a `releaseVersion` and a `nextVersion`. This updates the version, the changelog and creates a tag and finally creates a new draft release.
2. publish-release: This is triggered, when the previously draft release is published. It will upload the extension to the marketplace.
3. update-pmd: This updates PMD to the latest version and creates a new pull request.

Fixes #95 

