### PR TITLE
Upgrade actions and node

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,8 +15,8 @@ jobs:
         os: [macos-latest, ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-node@v3
+    - uses: actions/checkout@v4
+    - uses: actions/setup-node@v4
       with:
         node-version: 18
         cache: 'npm'
@@ -32,7 +32,7 @@ jobs:
       if: runner.os == 'Linux'
       run: npm run vscode:package
     - name: Upload extension
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: runner.os == 'Linux'
       with:
         name: vscode-apex-pmd

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/setup-node@v4
       with:
-        node-version: 18
+        node-version: 20
         cache: 'npm'
     - name: Install npm dependencies
       run: npm ci

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 ### Changed
+
+- Upgraded github actions and node by @adangel in [#161](https://github.com/ChuckJonas/vscode-apex-pmd/pull/161)
+
 ### Deprecated
 ### Removed
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@types/vscode": "1.43.0",
         "@typescript-eslint/eslint-plugin": "^2.30.0",
         "@typescript-eslint/parser": "^2.30.0",
-        "@vscode/test-electron": "^2.3.4",
+        "@vscode/test-electron": "^2.3.9",
         "cross-env": "^7.0.3",
         "eslint": "^6.8.0",
         "eslint-config-prettier": "^6.11.0",
@@ -331,9 +331,9 @@
       }
     },
     "node_modules/@vscode/test-electron": {
-      "version": "2.3.4",
-      "resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-2.3.4.tgz",
-      "integrity": "sha512-eWzIqXMhvlcoXfEFNWrVu/yYT5w6De+WZXR/bafUQhAp8+8GkQo95Oe14phwiRUPv8L+geAKl/QM2+PoT3YW3g==",
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-2.3.9.tgz",
+      "integrity": "sha512-z3eiChaCQXMqBnk2aHHSEkobmC2VRalFQN0ApOAtydL172zXGxTwGrRtviT5HnUB+Q+G3vtEYFtuQkYqBzYgMA==",
       "dev": true,
       "dependencies": {
         "http-proxy-agent": "^4.0.1",

--- a/package.json
+++ b/package.json
@@ -194,7 +194,7 @@
     "ts-loader": "^8.0.2",
     "tslint": "^5.16.0",
     "typescript": "^3.8.3",
-    "@vscode/test-electron": "^2.3.4",
+    "@vscode/test-electron": "^2.3.9",
     "webpack": "^5.88.2",
     "webpack-cli": "^5.1.4"
   },


### PR DESCRIPTION
- actions/checkout from v3 to v4
- actions/setup-node from v3 to v4
- actions/upload-artifact from v3 to v4
- node from 18 to 20
- @vscode/test-electron from 2.3.4 to 2.3.9
  - this fixes CI test issues on Windows and MacOS
