### PR TITLE
Fix #157: Set env PMD_APEX_ROOT_DIRECTORY

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ pmd-packager/target
 *.vsix
 dist/
 test/assets/project2 - with space/pmd-copy
+test/assets_temp

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Support for environment variable PMD_APEX_ROOT_DIRECTORY by @gparada in [#157](https://github.com/ChuckJonas/vscode-apex-pmd/issues/157)
   and by @adangel in [#180](https://github.com/ChuckJonas/vscode-apex-pmd/pull/180)
+- New configuration property "apexPMD.apexRootDirectory"
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+
+- Support for environment variable PMD_APEX_ROOT_DIRECTORY ([#157](https://github.com/ChuckJonas/vscode-apex-pmd/issues/157))
+
 ### Changed
+
+- Configuration properties are organized now in 4 sections. The names of the properties stay the same. The sections
+  are:
+  * Events
+  * Rule Configurations
+  * Violation Handling
+  * PMD Execution
+
 ### Deprecated
 ### Removed
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Support for environment variable PMD_APEX_ROOT_DIRECTORY ([#157](https://github.com/ChuckJonas/vscode-apex-pmd/issues/157))
+- Support for environment variable PMD_APEX_ROOT_DIRECTORY by @gparada in [#157](https://github.com/ChuckJonas/vscode-apex-pmd/issues/157)
+  and by @adangel in [#180](https://github.com/ChuckJonas/vscode-apex-pmd/pull/180)
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,17 @@ To start the command you can click in the menu on `Help/Show All Commands` or pr
 - `additionalClassPaths` (optional): set of paths to be appended to classpath. Used to find jar files containing custom rule definitions. Can be absolute or relative to workspace.
 - `commandBufferSize` Size of buffer used to collect PMD command output (MB), may need to be increased for very large projects
 - `jrePath` (Optional) Path to JRE (Folder that contains which contains `bin/java`)
+- `apexRootDirectory` (optional, since 0.9.0): Whether and how to set `PMD_APEX_ROOT_DIRECTORY` env variable. This
+   variable should point to the sfdx project directory, which contains the file `sfdx-project.json`.  
+   
+   This is needed for the rule [UnusedMethod](https://docs.pmd-code.org/latest/pmd_rules_apex_design.html#unusedmethod)
+   which utilizes [Apex Language Server](https://github.com/apex-dev-tools/apex-ls) which needs a well-formed sfdx
+   project.  
+   * off = Do not set `PMD_APEX_ROOT_DIRECTORY` at all
+   * automatic = (default) Automatically find the nearest `sfdx-project.json` file in a parent directory and use
+     that directory
+   * custom = Use a custom location for `PMD_APEX_ROOT_DIRECTORY` provided by "customValue". It should point to the
+     directory where the `sfdx-project.json` file is located. This is only used, if the "mode"=="custom".
 
 ### Defining your own "Ruleset"
 

--- a/package.json
+++ b/package.json
@@ -146,6 +146,25 @@
         "apexPMD.jrePath": {
           "type": "string",
           "description": "(Optional) Path to JRE (Folder that contains which contains `bin/java`)"
+        },
+        "apexPMD.apexRootDirectory": {
+          "type": "object",
+          "default": {
+            "mode": "automatic"
+          },
+          "markdownDescription": "Whether and how to set `PMD_APEX_ROOT_DIRECTORY` env variable. This variable should point to the sfdx project directory, which contains the file `sfdx-project.json`.\n\nThis is needed for the rule [UnusedMethod](https://docs.pmd-code.org/latest/pmd_rules_apex_design.html#unusedmethod) which utilizes [Apex Language Server](https://github.com/apex-dev-tools/apex-ls) which needs a well-formed sfdx project.\n\n* off = Do not set `PMD_APEX_ROOT_DIRECTORY` at all\n* automatic = (default) Automatically find the nearest `sfdx-project.json` file in a parent directory and use that directory\n* custom = Use a custom location for `PMD_APEX_ROOT_DIRECTORY` provided by \"customValue\". It should point to the directory where the `sfdx-project.json` file is located. This is only used, if the \"mode\"==\"custom\".",
+          "additionalProperties": false,
+          "properties": {
+            "mode": {
+              "type": "string",
+              "enum": ["off", "automatic", "custom"],
+              "default": "automatic"
+            },
+            "customValue": {
+              "type": "string",
+              "default": ""
+            }
+          }
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -78,96 +78,123 @@
         ]
       }
     ],
-    "configuration": {
-      "type": "object",
-      "title": "Apex PMD configuration",
-      "properties": {
-        "apexPMD.pmdBinPath": {
-          "type": "string",
-          "default": "",
-          "description": "(Optional) Path to where PMD was installed"
-        },
-        "apexPMD.rulesets": {
-          "type": "array",
-          "items": {
-            "type": "string"
+    "configuration": [
+      {
+        "title": "Events",
+        "properties": {
+          "apexPMD.runOnFileOpen": {
+            "type": "boolean",
+            "default": false,
+            "description": "Will run static analysis every time a file is opened",
+            "order": 1
           },
-          "default": [],
-          "description": "(Optional) Paths to rulesets' xml files."
-        },
-        "apexPMD.runOnFileOpen": {
-          "type": "boolean",
-          "default": false,
-          "description": "Will run static analysis every time a file is opened"
-        },
-        "apexPMD.runOnFileSave": {
-          "type": "boolean",
-          "default": true,
-          "description": "Will run static analysis every time a file is saved"
-        },
-        "apexPMD.runOnFileChange": {
-          "type": "boolean",
-          "default": false,
-          "description": "Will run static analysis every time a file is changed (with a 500ms debounce delay)"
-        },
-        "apexPMD.onFileChangeDebounce": {
-          "type": "integer",
-          "default": 3000,
-          "description": "Debounce interval to wait before running pmd after document change.  Only applicable if `runOnFileChange == true`"
-        },
-        "apexPMD.priorityErrorThreshold": {
-          "type": "number",
-          "default": 1,
-          "description": "Determines at what priority level 'errors' will be added. Anything less will be a warning or hint"
-        },
-        "apexPMD.priorityWarnThreshold": {
-          "type": "number",
-          "default": 3,
-          "description": "Determines at what priority level 'warnings' will be added. Anything less will be a hint"
-        },
-        "apexPMD.enableCache": {
-          "type": "boolean",
-          "default": false,
-          "description": "Creates a cache file for PMD to run faster. Will create a .pmdCache file in your workspace"
-        },
-        "apexPMD.additionalClassPaths": {
-          "type": "array",
-          "items": {
-            "type": "string"
+          "apexPMD.runOnFileSave": {
+            "type": "boolean",
+            "default": true,
+            "description": "Will run static analysis every time a file is saved",
+            "order": 2
           },
-          "default": [],
-          "description": "(Optional) paths to be appended to classpath. Used to find jar files containing custom rule definitions. Can be absolute or relative to workspace."
-        },
-        "apexPMD.commandBufferSize": {
-          "type": "number",
-          "default": "64",
-          "description": "Size of buffer used to collect PMD command output (MB), may need to be increased for very large projects"
-        },
-        "apexPMD.jrePath": {
-          "type": "string",
-          "description": "(Optional) Path to JRE (Folder that contains which contains `bin/java`)"
-        },
-        "apexPMD.apexRootDirectory": {
-          "type": "object",
-          "default": {
-            "mode": "automatic"
+          "apexPMD.runOnFileChange": {
+            "type": "boolean",
+            "default": false,
+            "description": "Will run static analysis every time a file is changed (with a 500ms debounce delay)",
+            "order": 3
           },
-          "markdownDescription": "Whether and how to set `PMD_APEX_ROOT_DIRECTORY` env variable. This variable should point to the sfdx project directory, which contains the file `sfdx-project.json`.\n\nThis is needed for the rule [UnusedMethod](https://docs.pmd-code.org/latest/pmd_rules_apex_design.html#unusedmethod) which utilizes [Apex Language Server](https://github.com/apex-dev-tools/apex-ls) which needs a well-formed sfdx project.\n\n* off = Do not set `PMD_APEX_ROOT_DIRECTORY` at all\n* automatic = (default) Automatically find the nearest `sfdx-project.json` file in a parent directory and use that directory\n* custom = Use a custom location for `PMD_APEX_ROOT_DIRECTORY` provided by \"customValue\". It should point to the directory where the `sfdx-project.json` file is located. This is only used, if the \"mode\"==\"custom\".",
-          "additionalProperties": false,
-          "properties": {
-            "mode": {
-              "type": "string",
-              "enum": ["off", "automatic", "custom"],
-              "default": "automatic"
+          "apexPMD.onFileChangeDebounce": {
+            "type": "integer",
+            "default": 3000,
+            "description": "Debounce interval to wait before running pmd after document change.  Only applicable if `runOnFileChange == true`",
+            "order": 4
+          }
+        }
+      },
+      {
+        "title": "Rule Configurations",
+        "properties": {
+          "apexPMD.rulesets": {
+            "type": "array",
+            "items": {
+              "type": "string"
             },
-            "customValue": {
-              "type": "string",
-              "default": ""
-            }
+            "default": [],
+            "description": "(Optional) Paths to rulesets' xml files.",
+            "order": 1
+          },
+          "apexPMD.additionalClassPaths": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "default": [],
+            "description": "(Optional) paths to be appended to classpath. Used to find jar files containing custom rule definitions. Can be absolute or relative to workspace.",
+            "order": 2
+          },
+          "apexPMD.apexRootDirectory": {
+            "type": "object",
+            "default": {
+              "mode": "automatic"
+            },
+            "markdownDescription": "Whether and how to set `PMD_APEX_ROOT_DIRECTORY` env variable. This variable should point to the sfdx project directory, which contains the file `sfdx-project.json`.\n\nThis is needed for the rule [UnusedMethod](https://docs.pmd-code.org/latest/pmd_rules_apex_design.html#unusedmethod) which utilizes [Apex Language Server](https://github.com/apex-dev-tools/apex-ls) which needs a well-formed sfdx project.\n\n* off = Do not set `PMD_APEX_ROOT_DIRECTORY` at all\n* automatic = (default) Automatically find the nearest `sfdx-project.json` file in a parent directory and use that directory\n* custom = Use a custom location for `PMD_APEX_ROOT_DIRECTORY` provided by \"customValue\". It should point to the directory where the `sfdx-project.json` file is located. This is only used, if the \"mode\"==\"custom\".",
+            "additionalProperties": false,
+            "properties": {
+              "mode": {
+                "type": "string",
+                "enum": ["off", "automatic", "custom"],
+                "default": "automatic"
+              },
+              "customValue": {
+                "type": "string",
+                "default": ""
+              }
+            },
+            "order": 3
+          }
+        }
+      },
+      {
+        "title": "Violation Handling",
+        "properties": {
+          "apexPMD.priorityErrorThreshold": {
+            "type": "number",
+            "default": 1,
+            "description": "Determines at what priority level 'errors' will be added. Anything less will be a warning or hint"
+          },
+          "apexPMD.priorityWarnThreshold": {
+            "type": "number",
+            "default": 3,
+            "description": "Determines at what priority level 'warnings' will be added. Anything less will be a hint"
+          }
+        }
+      },
+      {
+        "title": "PMD Execution",
+        "properties": {
+          "apexPMD.jrePath": {
+            "type": "string",
+            "description": "(Optional) Path to JRE (Folder that contains which contains `bin/java`)",
+            "order": 1
+          },
+          "apexPMD.pmdBinPath": {
+            "type": "string",
+            "default": "",
+            "description": "(Optional) Path to where PMD was installed",
+            "order": 2
+          },
+          "apexPMD.enableCache": {
+            "type": "boolean",
+            "default": false,
+            "description": "Creates a cache file for PMD to run faster. Will create a .pmdCache file in your workspace",
+            "order": 3
+          },
+          "apexPMD.commandBufferSize": {
+            "type": "number",
+            "default": "64",
+            "description": "Size of buffer used to collect PMD command output (MB), may need to be increased for very large projects",
+            "order": 4
           }
         }
       }
-    },
+    ],
     "menus": {
       "explorer/context": [
         {

--- a/src/lib/apexPmd.ts
+++ b/src/lib/apexPmd.ts
@@ -120,6 +120,7 @@ export class ApexPmd {
       pmdBinPath,
       additionalClassPaths,
       commandBufferSize,
+      apexRootDirectory,
     } = this.config;
 
     // -R Comma-separated list of ruleset or rule references.
@@ -150,7 +151,14 @@ export class ApexPmd {
       }
     }
 
-    env["PMD_APEX_ROOT_DIRECTORY"] = findSfdxProject(targetPath, workspaceRootPath);
+    switch (apexRootDirectory.mode) {
+      case "automatic":
+        env["PMD_APEX_ROOT_DIRECTORY"] = findSfdxProject(targetPath, workspaceRootPath);
+        break;
+      case "custom":
+        env["PMD_APEX_ROOT_DIRECTORY"] = apexRootDirectory.custom ?? '';
+        break;
+    }
 
     const cmd = `"${path.join(pmdBinPath, 'bin', 'pmd')}" check ${pmdKeys}`;
 

--- a/src/lib/apexPmd.ts
+++ b/src/lib/apexPmd.ts
@@ -4,7 +4,7 @@ import * as path from 'path';
 import { Config } from './config';
 import { AppStatus } from './appStatus';
 import * as os from 'os';
-import { fileExists, dirExists } from './utils';
+import { fileExists, dirExists, findSfdxProject } from './utils';
 import { parsePmdCsv } from './pmdCsvParser';
 
 //setup OS constants
@@ -150,8 +150,7 @@ export class ApexPmd {
       }
     }
 
-    // TODO: determine the nearest sfdx-project.json file beginning from targetPath up to workspaceRootPath
-    env["PMD_APEX_ROOT_DIRECTORY"] = workspaceRootPath;
+    env["PMD_APEX_ROOT_DIRECTORY"] = findSfdxProject(targetPath, workspaceRootPath);
 
     const cmd = `"${path.join(pmdBinPath, 'bin', 'pmd')}" check ${pmdKeys}`;
 

--- a/src/lib/apexPmd.ts
+++ b/src/lib/apexPmd.ts
@@ -150,6 +150,9 @@ export class ApexPmd {
       }
     }
 
+    // TODO: determine the nearest sfdx-project.json file beginning from targetPath up to workspaceRootPath
+    env["PMD_APEX_ROOT_DIRECTORY"] = workspaceRootPath;
+
     const cmd = `"${path.join(pmdBinPath, 'bin', 'pmd')}" check ${pmdKeys}`;
 
     this.outputChannel.appendLine(`node: ${process.version}`);

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -26,7 +26,10 @@ export class Config {
       this._ctx = ctx;
       this.init();
     } else {
-      console.warn('VSCode ApexPMD missing configuration');
+      const isTest = global['test'] !== undefined;
+      if (!isTest) {
+        throw new Error('VSCode ApexPMD missing configuration');
+      }
     }
   }
 

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -3,6 +3,11 @@ import * as vscode from 'vscode';
 import * as path from 'path';
 import { getRootWorkspacePath } from './utils';
 
+interface ApexRootDirectory {
+  mode: "off" | "automatic" | "custom";
+  custom?: string;
+}
+
 export class Config {
   private _rulesetPath: string;
   public workspaceRootPath: string;
@@ -18,6 +23,7 @@ export class Config {
   public additionalClassPaths: string[];
   public commandBufferSize: number;
   public jrePath: string;
+  public apexRootDirectory: ApexRootDirectory;
 
   private _ctx: vscode.ExtensionContext;
 
@@ -30,10 +36,11 @@ export class Config {
       if (!isTest) {
         throw new Error('VSCode ApexPMD missing configuration');
       }
+      this.readConfig();
     }
   }
 
-  public init() {
+  private readConfig() {
     const config = vscode.workspace.getConfiguration('apexPMD');
     // deprecated setting is left for backward compatibility
     this._rulesetPath = config.get('rulesetPath');
@@ -50,6 +57,11 @@ export class Config {
     this.additionalClassPaths = config.get('additionalClassPaths');
     this.commandBufferSize = config.get('commandBufferSize');
     this.jrePath = config.get('jrePath');
+    this.apexRootDirectory = config.get('apexRootDirectory');
+  }
+
+  public init() {
+    this.readConfig();
     this.resolvePaths();
   }
 

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,6 +1,7 @@
 //=== Util ===
 import * as fs from 'fs';
 import * as vscode from 'vscode';
+import * as path from 'path';
 
 export function getRootWorkspacePath(): string {
   const ws = vscode.workspace;
@@ -28,4 +29,18 @@ export function dirExists(filePath: string): boolean {
 
 export function stripQuotes(s: string): string {
   return s.substr(1, s.length - 2);
+}
+
+export function findSfdxProject(startFile: string, defaultFallback: string): string {
+  let currentDir = path.dirname(startFile);
+  while (currentDir !== '') {
+    let found = fs.readdirSync(currentDir).some(s => 'sfdx-project.json' === s);
+    if (found) {
+      return currentDir;
+    }
+    let paths = currentDir.split(path.sep);
+    paths.pop(); // remove last
+    currentDir = paths.join(path.sep);
+  }
+  return defaultFallback;
 }

--- a/test/assets/project3_unusedmethod/custom_ruleset.xml
+++ b/test/assets/project3_unusedmethod/custom_ruleset.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ruleset xmlns="http://pmd.sourceforge.net/ruleset/2.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+   name="Test ruleset" xsi:schemaLocation="http://pmd.sourceforge.net/ruleset/2.0.0 http://pmd.sourceforge.net/ruleset_2_0_0.xsd">
+   <description>Test ruleset</description>
+
+      <rule ref="category/apex/design.xml/UnusedMethod" />
+
+</ruleset>

--- a/test/assets/project3_unusedmethod/sfdx-project.json
+++ b/test/assets/project3_unusedmethod/sfdx-project.json
@@ -1,0 +1,9 @@
+{
+  "packageDirectories": [
+    {
+      "path": "src",
+      "default": true
+    }
+  ],
+  "namespace": "foo_ns"
+}

--- a/test/assets/project3_unusedmethod/src/Foo.cls
+++ b/test/assets/project3_unusedmethod/src/Foo.cls
@@ -1,0 +1,9 @@
+public class Foo {
+    // this method is needed, otherwise the whole class is considered as unused, as it would contain
+    // then only one unused method.
+    private void other() {}
+
+    public void unusedMethod() {
+        other();
+    }
+}

--- a/test/assets/project3_unusedmethod/src/Foo.cls-meta.xml
+++ b/test/assets/project3_unusedmethod/src/Foo.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>50.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/test/suite/apexRootDirectory.test.ts
+++ b/test/suite/apexRootDirectory.test.ts
@@ -1,0 +1,193 @@
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+import * as path from 'path';
+import { ApexPmd } from '../../src/extension';
+import { Config } from '../../src/lib/config';
+import * as fs from 'fs';
+import { TestUtils } from './test-utils';
+
+const PMD_PATH = path.join(__dirname, '..', '..', '..', 'bin', 'pmd');
+const TEST_ASSETS_PATH = path.join(__dirname, '..', '..', '..', 'test', 'assets');
+const TEST_ASSETS_TEMP_PATH = path.join(__dirname, '..', '..', '..', 'test', 'assets_temp');
+
+const outputChannel = vscode.window.createOutputChannel('Apex PMD');
+
+suite('Apex Root Directory related tests', () => {
+  test('UnusedMethod with Apex Link and PMD_APEX_ROOT_DIRECTORY as workspace root (default automatic)', function (done) {
+    this.timeout(100000);
+
+    const workspaceRootPath = path.join(TEST_ASSETS_PATH, 'project3_unusedmethod');
+    const rulesetPath = path.join(workspaceRootPath, 'custom_ruleset.xml');
+    const apexClassFile = path.join(workspaceRootPath, 'src', 'Foo.cls');
+
+    const collection = vscode.languages.createDiagnosticCollection('apex-pmd-test');
+
+    const config = new Config();
+    config.pmdBinPath = PMD_PATH;
+    config.rulesets = [rulesetPath];
+    config.priorityErrorThreshold = 3;
+    config.priorityWarnThreshold = 1;
+    config.workspaceRootPath = workspaceRootPath;
+    config.additionalClassPaths = [];
+    config.commandBufferSize = 64000000;
+
+    const pmd = new ApexPmd(outputChannel, config);
+
+    const testApexUri = vscode.Uri.file(apexClassFile);
+    pmd
+      .run(apexClassFile, collection)
+      .then(() => {
+        const errs = collection.get(testApexUri);
+        assert.strictEqual(errs.length, 1, "Wrong number of found violations");
+        assert.strictEqual(errs[0].message, "Unused methods make understanding code harder (rule: Design-UnusedMethod)");
+        done();
+      })
+      .catch((e) => {
+        done(e);
+      });
+  });
+
+  test('UnusedMethod with Apex Link and PMD_APEX_ROOT_DIRECTORY as workspace root (off)', function (done) {
+    this.timeout(100000);
+
+    const workspaceRootPath = path.join(TEST_ASSETS_PATH, 'project3_unusedmethod');
+    const rulesetPath = path.join(workspaceRootPath, 'custom_ruleset.xml');
+    const apexClassFile = path.join(workspaceRootPath, 'src', 'Foo.cls');
+
+    const collection = vscode.languages.createDiagnosticCollection('apex-pmd-test');
+
+    const config = new Config();
+    config.pmdBinPath = PMD_PATH;
+    config.rulesets = [rulesetPath];
+    config.priorityErrorThreshold = 3;
+    config.priorityWarnThreshold = 1;
+    config.workspaceRootPath = workspaceRootPath;
+    config.additionalClassPaths = [];
+    config.commandBufferSize = 64000000;
+    config.apexRootDirectory = { "mode": "off" };
+
+    const pmd = new ApexPmd(outputChannel, config);
+
+    const testApexUri = vscode.Uri.file(apexClassFile);
+    pmd
+      .run(apexClassFile, collection)
+      .then(() => {
+        const errs = collection.get(testApexUri);
+        // we don't detect the violation, as ApexLink is not setup correctly (sfdx-project.json is not used)
+        assert.strictEqual(errs.length, 0, "Wrong number of found violations");
+        done();
+      })
+      .catch((e) => {
+        done(e);
+      });
+  });
+
+  test('UnusedMethod with Apex Link and PMD_APEX_ROOT_DIRECTORY as subdirectory (default automatic)', function (done) {
+    this.timeout(100000);
+
+    // copy the original sample project and create a subfolder structure
+    const workspaceRootPath = path.join(TEST_ASSETS_TEMP_PATH, 'project3_unusedmethod_subdir');
+    const sourcePath = path.join(TEST_ASSETS_PATH, 'project3_unusedmethod');
+    TestUtils.deleteDirectory(workspaceRootPath)
+    fs.mkdirSync(workspaceRootPath, { recursive: true });
+    TestUtils.copyDirectory(sourcePath, path.join(workspaceRootPath, 'module'));
+
+
+    const rulesetPath = path.join(workspaceRootPath, 'module', 'custom_ruleset.xml');
+    const apexClassFile = path.join(workspaceRootPath, 'module', 'src', 'Foo.cls');
+
+    const collection = vscode.languages.createDiagnosticCollection('apex-pmd-test');
+
+    const config = new Config();
+    config.pmdBinPath = PMD_PATH;
+    config.rulesets = [rulesetPath];
+    config.priorityErrorThreshold = 3;
+    config.priorityWarnThreshold = 1;
+    config.workspaceRootPath = workspaceRootPath;
+    config.additionalClassPaths = [];
+    config.commandBufferSize = 64000000;
+
+    const pmd = new ApexPmd(outputChannel, config);
+
+    const testApexUri = vscode.Uri.file(apexClassFile);
+    pmd
+      .run(apexClassFile, collection)
+      .then(() => {
+        const errs = collection.get(testApexUri);
+        assert.strictEqual(errs.length, 1, "Wrong number of found violations");
+        assert.strictEqual(errs[0].message, "Unused methods make understanding code harder (rule: Design-UnusedMethod)");
+        done();
+      })
+      .catch((e) => {
+        done(e);
+      });
+  });
+
+  test('UnusedMethod with Apex Link and PMD_APEX_ROOT_DIRECTORY with weird folder structure (custom)', function (done) {
+    this.timeout(100000);
+
+    // copy the original sample project and create a subfolder structure
+    const workspaceRootPath = path.join(TEST_ASSETS_TEMP_PATH, 'project3_unusedmethod_weird');
+    const sourcePath = path.join(TEST_ASSETS_PATH, 'project3_unusedmethod');
+    TestUtils.deleteDirectory(workspaceRootPath)
+    fs.mkdirSync(path.join(workspaceRootPath, 'subdir'), { recursive: true });
+    TestUtils.copyDirectory(sourcePath, path.join(workspaceRootPath, 'subdir', 'module'));
+    // replace the original sfdx-project.json file in subdir/module with a broken one
+    fs.unlinkSync(path.join(workspaceRootPath, 'subdir', 'module', 'sfdx-project.json'));
+    // it's broken because of referencing paths _not within_ the project
+    fs.writeFileSync(path.join(workspaceRootPath, 'subdir', 'module', 'sfdx-project.json'), `
+        {
+          "packageDirectories": [
+            {
+              "path": "../some-other-directory/src",
+              "default": true
+            }
+          ],
+          "namespace": "foo_ns"
+        }
+        `);
+    // and create a new one in the parent directory (subdir) - but not in workspaceRoot (that would be a default fallback).
+    fs.writeFileSync(path.join(workspaceRootPath, 'subdir', 'sfdx-project.json'), `
+      {
+        "packageDirectories": [
+          {
+            "path": "module/src",
+            "default": true
+          }
+        ],
+        "namespace": "foo_ns"
+      }
+      `);
+
+    const rulesetPath = path.join(workspaceRootPath, 'subdir', 'module', 'custom_ruleset.xml');
+    const apexClassFile = path.join(workspaceRootPath, 'subdir', 'module', 'src', 'Foo.cls');
+
+    const collection = vscode.languages.createDiagnosticCollection('apex-pmd-test');
+
+    const config = new Config();
+    config.pmdBinPath = PMD_PATH;
+    config.rulesets = [rulesetPath];
+    config.priorityErrorThreshold = 3;
+    config.priorityWarnThreshold = 1;
+    config.workspaceRootPath = workspaceRootPath;
+    config.additionalClassPaths = [];
+    config.commandBufferSize = 64000000;
+    config.apexRootDirectory = { "mode": "custom", "custom": path.join(workspaceRootPath, 'subdir') };
+
+    const pmd = new ApexPmd(outputChannel, config);
+
+    const testApexUri = vscode.Uri.file(apexClassFile);
+    pmd
+      .run(apexClassFile, collection)
+      .then(() => {
+        const errs = collection.get(testApexUri);
+        assert.strictEqual(errs.length, 1, "Wrong number of found violations");
+        assert.strictEqual(errs[0].message, "Unused methods make understanding code harder (rule: Design-UnusedMethod)");
+        done();
+      })
+      .catch((e) => {
+        done(e);
+      });
+  });
+
+});

--- a/test/suite/extension.test.ts
+++ b/test/suite/extension.test.ts
@@ -189,7 +189,7 @@ suite('Extension Tests', () => {
       });
   });
 
-  test('UnusedMethod with Apex Link and PMD_APEX_ROOT_DIRECTORY as workspace root', function (done) {
+  test('UnusedMethod with Apex Link and PMD_APEX_ROOT_DIRECTORY as workspace root (default automatic)', function (done) {
     this.timeout(100000);
 
     const workspaceRootPath = path.join(TEST_ASSETS_PATH, 'project3_unusedmethod');
@@ -223,7 +223,42 @@ suite('Extension Tests', () => {
       });
   });
 
-  test('UnusedMethod with Apex Link and PMD_APEX_ROOT_DIRECTORY as subdirectory', function (done) {
+  test('UnusedMethod with Apex Link and PMD_APEX_ROOT_DIRECTORY as workspace root (off)', function (done) {
+    this.timeout(100000);
+
+    const workspaceRootPath = path.join(TEST_ASSETS_PATH, 'project3_unusedmethod');
+    const rulesetPath = path.join(workspaceRootPath, 'custom_ruleset.xml');
+    const apexClassFile = path.join(workspaceRootPath, 'src', 'Foo.cls');
+
+    const collection = vscode.languages.createDiagnosticCollection('apex-pmd-test');
+
+    const config = new Config();
+    config.pmdBinPath = PMD_PATH;
+    config.rulesets = [rulesetPath];
+    config.priorityErrorThreshold = 3;
+    config.priorityWarnThreshold = 1;
+    config.workspaceRootPath = workspaceRootPath;
+    config.additionalClassPaths = [];
+    config.commandBufferSize = 64000000;
+    config.apexRootDirectory = { "mode": "off" };
+
+    const pmd = new ApexPmd(outputChannel, config);
+
+    const testApexUri = vscode.Uri.file(apexClassFile);
+    pmd
+      .run(apexClassFile, collection)
+      .then(() => {
+        const errs = collection.get(testApexUri);
+        // we don't detect the violation, as ApexLink is not setup correctly (sfdx-project.json is not used)
+        assert.strictEqual(errs.length, 0, "Wrong number of found violations");
+        done();
+      })
+      .catch((e) => {
+        done(e);
+      });
+  });
+
+  test('UnusedMethod with Apex Link and PMD_APEX_ROOT_DIRECTORY as subdirectory (default automatic)', function (done) {
     this.timeout(100000);
 
     // copy the original sample project and create a subfolder structure
@@ -247,6 +282,73 @@ suite('Extension Tests', () => {
     config.workspaceRootPath = workspaceRootPath;
     config.additionalClassPaths = [];
     config.commandBufferSize = 64000000;
+
+    const pmd = new ApexPmd(outputChannel, config);
+
+    const testApexUri = vscode.Uri.file(apexClassFile);
+    pmd
+      .run(apexClassFile, collection)
+      .then(() => {
+        const errs = collection.get(testApexUri);
+        assert.strictEqual(errs.length, 1, "Wrong number of found violations");
+        assert.strictEqual(errs[0].message, "Unused methods make understanding code harder (rule: Design-UnusedMethod)");
+        done();
+      })
+      .catch((e) => {
+        done(e);
+      });
+  });
+
+  test('UnusedMethod with Apex Link and PMD_APEX_ROOT_DIRECTORY with weird folder structure (custom)', function (done) {
+    this.timeout(100000);
+
+    // copy the original sample project and create a subfolder structure
+    const workspaceRootPath = path.join(TEST_ASSETS_TEMP_PATH, 'project3_unusedmethod_weird');
+    const sourcePath = path.join(TEST_ASSETS_PATH, 'project3_unusedmethod');
+    TestUtils.deleteDirectory(workspaceRootPath)
+    fs.mkdirSync(path.join(workspaceRootPath, 'subdir'), { recursive: true });
+    TestUtils.copyDirectory(sourcePath, path.join(workspaceRootPath, 'subdir', 'module'));
+    // replace the original sfdx-project.json file in subdir/module with a broken one
+    fs.unlinkSync(path.join(workspaceRootPath, 'subdir', 'module', 'sfdx-project.json'));
+    // it's broken because of referencing paths _not within_ the project
+    fs.writeFileSync(path.join(workspaceRootPath, 'subdir', 'module', 'sfdx-project.json'), `
+        {
+          "packageDirectories": [
+            {
+              "path": "../some-other-directory/src",
+              "default": true
+            }
+          ],
+          "namespace": "foo_ns"
+        }
+        `);
+    // and create a new one in the parent directory (subdir) - but not in workspaceRoot (that would be a default fallback).
+    fs.writeFileSync(path.join(workspaceRootPath, 'subdir', 'sfdx-project.json'), `
+      {
+        "packageDirectories": [
+          {
+            "path": "module/src",
+            "default": true
+          }
+        ],
+        "namespace": "foo_ns"
+      }
+      `);
+
+    const rulesetPath = path.join(workspaceRootPath, 'subdir', 'module', 'custom_ruleset.xml');
+    const apexClassFile = path.join(workspaceRootPath, 'subdir', 'module', 'src', 'Foo.cls');
+
+    const collection = vscode.languages.createDiagnosticCollection('apex-pmd-test');
+
+    const config = new Config();
+    config.pmdBinPath = PMD_PATH;
+    config.rulesets = [rulesetPath];
+    config.priorityErrorThreshold = 3;
+    config.priorityWarnThreshold = 1;
+    config.workspaceRootPath = workspaceRootPath;
+    config.additionalClassPaths = [];
+    config.commandBufferSize = 64000000;
+    config.apexRootDirectory = { "mode": "custom", "custom": path.join(workspaceRootPath, 'subdir') };
 
     const pmd = new ApexPmd(outputChannel, config);
 

--- a/test/suite/extension.test.ts
+++ b/test/suite/extension.test.ts
@@ -214,4 +214,38 @@ suite('Extension Tests', () => {
         done(e);
       });
   });
+
+  test('UnusedMethod with Apex Link and PMD_APEX_ROOT_DIRECTORY', function (done) {
+    this.timeout(100000);
+
+    const workspaceRootPath = path.join(TEST_ASSETS_PATH, 'project3_unusedmethod');
+    const rulesetPath = path.join(workspaceRootPath, 'custom_ruleset.xml');
+    const apexClassFile = path.join(workspaceRootPath, 'src', 'Foo.cls');
+
+    const collection = vscode.languages.createDiagnosticCollection('apex-pmd-test');
+
+    const config = new Config();
+    config.pmdBinPath = PMD_PATH;
+    config.rulesets = [rulesetPath];
+    config.priorityErrorThreshold = 3;
+    config.priorityWarnThreshold = 1;
+    config.workspaceRootPath = workspaceRootPath;
+    config.additionalClassPaths = [];
+    config.commandBufferSize = 64000000;
+
+    const pmd = new ApexPmd(outputChannel, config);
+
+    const testApexUri = vscode.Uri.file(apexClassFile);
+    pmd
+      .run(apexClassFile, collection)
+      .then(() => {
+        const errs = collection.get(testApexUri);
+        assert.strictEqual(errs.length, 1);
+        assert.strictEqual(errs[0].message, "Unused methods make understanding code harder (rule: Design-UnusedMethod)");
+        done();
+      })
+      .catch((e) => {
+        done(e);
+      });
+  });
 });

--- a/test/suite/extension.test.ts
+++ b/test/suite/extension.test.ts
@@ -33,10 +33,10 @@ suite('Apex PMD Tests', () => {
 
     const pmd = new ApexPmd(outputChannel, config);
 
-    assert.equal(pmd.checkPmdPath(), true);
-    assert.equal(pmd.getRulesets()[0], RULESET_PATH);
-    assert.equal(pmd.getRulesets().length, 1);
-    assert.equal(pmd.hasAtLeastOneValidRuleset(), true);
+    assert.strictEqual(pmd.checkPmdPath(), true);
+    assert.strictEqual(pmd.getRulesets()[0], RULESET_PATH);
+    assert.strictEqual(pmd.getRulesets().length, 1);
+    assert.strictEqual(pmd.hasAtLeastOneValidRuleset(), true);
   });
 
   test('test diagnostic warning', function (done) {
@@ -60,7 +60,7 @@ suite('Apex PMD Tests', () => {
       .run(TEST_APEX_PATH, collection)
       .then(() => {
         const errs = collection.get(testApexUri);
-        assert.equal(errs.length, 1);
+        assert.strictEqual(errs.length, 1);
         done();
       })
       .catch((e) => {

--- a/test/suite/extension.test.ts
+++ b/test/suite/extension.test.ts
@@ -12,19 +12,17 @@ import * as vscode from 'vscode';
 import * as path from 'path';
 import { ApexPmd } from '../../src/extension';
 import { Config } from '../../src/lib/config';
-import * as fs from 'fs';
 import { TestUtils } from './test-utils';
 
 const PMD_PATH = path.join(__dirname, '..', '..', '..', 'bin', 'pmd');
 const RULESET_PATH = path.join(__dirname, '..', '..', '..', 'rulesets', 'apex_ruleset.xml');
 const INVALID_RULESET_PATH = path.join(__dirname, '..', '..', '..', 'rulesets', 'apex_ruleset_invalid.xml');
 const TEST_ASSETS_PATH = path.join(__dirname, '..', '..', '..', 'test', 'assets');
-const TEST_ASSETS_TEMP_PATH = path.join(__dirname, '..', '..', '..', 'test', 'assets_temp');
 const TEST_APEX_PATH = path.join(TEST_ASSETS_PATH, 'test.cls');
 
 const outputChannel = vscode.window.createOutputChannel('Apex PMD');
 
-suite('Extension Tests', () => {
+suite('Apex PMD Tests', () => {
   test('check default paths', () => {
     const config = new Config();
     config.pmdBinPath = PMD_PATH;
@@ -182,183 +180,6 @@ suite('Extension Tests', () => {
         const code = diagnostic.code as {value :string };
         assert.strictEqual(code.value, "OperationWithLimitsInLoop");
         assert.strictEqual(diagnostic.range.start.line, 6); // vscode lines are 0-based
-        done();
-      })
-      .catch((e) => {
-        done(e);
-      });
-  });
-
-  test('UnusedMethod with Apex Link and PMD_APEX_ROOT_DIRECTORY as workspace root (default automatic)', function (done) {
-    this.timeout(100000);
-
-    const workspaceRootPath = path.join(TEST_ASSETS_PATH, 'project3_unusedmethod');
-    const rulesetPath = path.join(workspaceRootPath, 'custom_ruleset.xml');
-    const apexClassFile = path.join(workspaceRootPath, 'src', 'Foo.cls');
-
-    const collection = vscode.languages.createDiagnosticCollection('apex-pmd-test');
-
-    const config = new Config();
-    config.pmdBinPath = PMD_PATH;
-    config.rulesets = [rulesetPath];
-    config.priorityErrorThreshold = 3;
-    config.priorityWarnThreshold = 1;
-    config.workspaceRootPath = workspaceRootPath;
-    config.additionalClassPaths = [];
-    config.commandBufferSize = 64000000;
-
-    const pmd = new ApexPmd(outputChannel, config);
-
-    const testApexUri = vscode.Uri.file(apexClassFile);
-    pmd
-      .run(apexClassFile, collection)
-      .then(() => {
-        const errs = collection.get(testApexUri);
-        assert.strictEqual(errs.length, 1, "Wrong number of found violations");
-        assert.strictEqual(errs[0].message, "Unused methods make understanding code harder (rule: Design-UnusedMethod)");
-        done();
-      })
-      .catch((e) => {
-        done(e);
-      });
-  });
-
-  test('UnusedMethod with Apex Link and PMD_APEX_ROOT_DIRECTORY as workspace root (off)', function (done) {
-    this.timeout(100000);
-
-    const workspaceRootPath = path.join(TEST_ASSETS_PATH, 'project3_unusedmethod');
-    const rulesetPath = path.join(workspaceRootPath, 'custom_ruleset.xml');
-    const apexClassFile = path.join(workspaceRootPath, 'src', 'Foo.cls');
-
-    const collection = vscode.languages.createDiagnosticCollection('apex-pmd-test');
-
-    const config = new Config();
-    config.pmdBinPath = PMD_PATH;
-    config.rulesets = [rulesetPath];
-    config.priorityErrorThreshold = 3;
-    config.priorityWarnThreshold = 1;
-    config.workspaceRootPath = workspaceRootPath;
-    config.additionalClassPaths = [];
-    config.commandBufferSize = 64000000;
-    config.apexRootDirectory = { "mode": "off" };
-
-    const pmd = new ApexPmd(outputChannel, config);
-
-    const testApexUri = vscode.Uri.file(apexClassFile);
-    pmd
-      .run(apexClassFile, collection)
-      .then(() => {
-        const errs = collection.get(testApexUri);
-        // we don't detect the violation, as ApexLink is not setup correctly (sfdx-project.json is not used)
-        assert.strictEqual(errs.length, 0, "Wrong number of found violations");
-        done();
-      })
-      .catch((e) => {
-        done(e);
-      });
-  });
-
-  test('UnusedMethod with Apex Link and PMD_APEX_ROOT_DIRECTORY as subdirectory (default automatic)', function (done) {
-    this.timeout(100000);
-
-    // copy the original sample project and create a subfolder structure
-    const workspaceRootPath = path.join(TEST_ASSETS_TEMP_PATH, 'project3_unusedmethod_subdir');
-    const sourcePath = path.join(TEST_ASSETS_PATH, 'project3_unusedmethod');
-    TestUtils.deleteDirectory(workspaceRootPath)
-    fs.mkdirSync(workspaceRootPath, { recursive: true });
-    TestUtils.copyDirectory(sourcePath, path.join(workspaceRootPath, 'module'));
-
-
-    const rulesetPath = path.join(workspaceRootPath, 'module', 'custom_ruleset.xml');
-    const apexClassFile = path.join(workspaceRootPath, 'module', 'src', 'Foo.cls');
-
-    const collection = vscode.languages.createDiagnosticCollection('apex-pmd-test');
-
-    const config = new Config();
-    config.pmdBinPath = PMD_PATH;
-    config.rulesets = [rulesetPath];
-    config.priorityErrorThreshold = 3;
-    config.priorityWarnThreshold = 1;
-    config.workspaceRootPath = workspaceRootPath;
-    config.additionalClassPaths = [];
-    config.commandBufferSize = 64000000;
-
-    const pmd = new ApexPmd(outputChannel, config);
-
-    const testApexUri = vscode.Uri.file(apexClassFile);
-    pmd
-      .run(apexClassFile, collection)
-      .then(() => {
-        const errs = collection.get(testApexUri);
-        assert.strictEqual(errs.length, 1, "Wrong number of found violations");
-        assert.strictEqual(errs[0].message, "Unused methods make understanding code harder (rule: Design-UnusedMethod)");
-        done();
-      })
-      .catch((e) => {
-        done(e);
-      });
-  });
-
-  test('UnusedMethod with Apex Link and PMD_APEX_ROOT_DIRECTORY with weird folder structure (custom)', function (done) {
-    this.timeout(100000);
-
-    // copy the original sample project and create a subfolder structure
-    const workspaceRootPath = path.join(TEST_ASSETS_TEMP_PATH, 'project3_unusedmethod_weird');
-    const sourcePath = path.join(TEST_ASSETS_PATH, 'project3_unusedmethod');
-    TestUtils.deleteDirectory(workspaceRootPath)
-    fs.mkdirSync(path.join(workspaceRootPath, 'subdir'), { recursive: true });
-    TestUtils.copyDirectory(sourcePath, path.join(workspaceRootPath, 'subdir', 'module'));
-    // replace the original sfdx-project.json file in subdir/module with a broken one
-    fs.unlinkSync(path.join(workspaceRootPath, 'subdir', 'module', 'sfdx-project.json'));
-    // it's broken because of referencing paths _not within_ the project
-    fs.writeFileSync(path.join(workspaceRootPath, 'subdir', 'module', 'sfdx-project.json'), `
-        {
-          "packageDirectories": [
-            {
-              "path": "../some-other-directory/src",
-              "default": true
-            }
-          ],
-          "namespace": "foo_ns"
-        }
-        `);
-    // and create a new one in the parent directory (subdir) - but not in workspaceRoot (that would be a default fallback).
-    fs.writeFileSync(path.join(workspaceRootPath, 'subdir', 'sfdx-project.json'), `
-      {
-        "packageDirectories": [
-          {
-            "path": "module/src",
-            "default": true
-          }
-        ],
-        "namespace": "foo_ns"
-      }
-      `);
-
-    const rulesetPath = path.join(workspaceRootPath, 'subdir', 'module', 'custom_ruleset.xml');
-    const apexClassFile = path.join(workspaceRootPath, 'subdir', 'module', 'src', 'Foo.cls');
-
-    const collection = vscode.languages.createDiagnosticCollection('apex-pmd-test');
-
-    const config = new Config();
-    config.pmdBinPath = PMD_PATH;
-    config.rulesets = [rulesetPath];
-    config.priorityErrorThreshold = 3;
-    config.priorityWarnThreshold = 1;
-    config.workspaceRootPath = workspaceRootPath;
-    config.additionalClassPaths = [];
-    config.commandBufferSize = 64000000;
-    config.apexRootDirectory = { "mode": "custom", "custom": path.join(workspaceRootPath, 'subdir') };
-
-    const pmd = new ApexPmd(outputChannel, config);
-
-    const testApexUri = vscode.Uri.file(apexClassFile);
-    pmd
-      .run(apexClassFile, collection)
-      .then(() => {
-        const errs = collection.get(testApexUri);
-        assert.strictEqual(errs.length, 1, "Wrong number of found violations");
-        assert.strictEqual(errs[0].message, "Unused methods make understanding code harder (rule: Design-UnusedMethod)");
         done();
       })
       .catch((e) => {

--- a/test/suite/extension.test.ts
+++ b/test/suite/extension.test.ts
@@ -13,6 +13,7 @@ import * as path from 'path';
 import { ApexPmd } from '../../src/extension';
 import { Config } from '../../src/lib/config';
 import * as fs from 'fs';
+import { TestUtils } from './test-utils';
 
 const PMD_PATH = path.join(__dirname, '..', '..', '..', 'bin', 'pmd');
 const RULESET_PATH = path.join(__dirname, '..', '..', '..', 'rulesets', 'apex_ruleset.xml');
@@ -151,36 +152,8 @@ suite('Extension Tests', () => {
     // symlinks are not really supported by win32/git. Under Windows, the user needs extra permissions.
     // That's why after git clone/checkout, the symlink is not properly restored (core.symlinks is by default false).
     // We simply copy the whole directory into workspace...
-    const copyDirectory = function(source : string, destination : string) {
-      for (const file of fs.readdirSync(source)) {
-        const originalFilePath = path.join(source, file);
-        const targetFilePath = path.join(destination, file);
-        const stat = fs.statSync(originalFilePath);
-        if (stat.isFile()) {
-          fs.copyFileSync(originalFilePath, targetFilePath);
-        } else if (stat.isDirectory()) {
-          fs.mkdirSync(targetFilePath);
-          copyDirectory(originalFilePath, targetFilePath);
-        }
-      }
-    }
-    const deleteDirectory = function(dir : string) {
-      for (const file of fs.readdirSync(dir)) {
-        const filePath = path.join(dir, file);
-        const stat = fs.statSync(filePath);
-        if (stat.isFile()) {
-          fs.unlinkSync(filePath);
-        } else if (stat.isDirectory()) {
-          deleteDirectory(filePath);
-        }
-      }
-      fs.rmdirSync(dir);
-    }
-    if (fs.existsSync(pmdBinPath)) {
-      deleteDirectory(pmdBinPath);
-    }
-    fs.mkdirSync(pmdBinPath);
-    copyDirectory(pmdBinSource, pmdBinPath);
+    TestUtils.deleteDirectory(pmdBinPath);
+    TestUtils.copyDirectory(pmdBinSource, pmdBinPath);
 
     const apexClassFile = path.join(workspaceRootPath, 'test.cls');
 

--- a/test/suite/test-utils.ts
+++ b/test/suite/test-utils.ts
@@ -1,0 +1,57 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+const TestUtils = {
+    /**
+     * Recursively copies a directory.
+     * Creates the destination directory, if it doesn't exist yet.
+     *
+     * @param source source path
+     * @param destination destination path
+     */
+    copyDirectory: function(source : string, destination : string) {
+      if (fs.existsSync(destination)) {
+        throw new Error(`Destination directory (or file) ${destination} already exists, won't copy!`);
+      }
+
+      fs.mkdirSync(destination);
+      for (const file of fs.readdirSync(source)) {
+        const originalFilePath = path.join(source, file);
+        const targetFilePath = path.join(destination, file);
+        const stat = fs.statSync(originalFilePath);
+        if (stat.isFile()) {
+          fs.copyFileSync(originalFilePath, targetFilePath);
+        } else if (stat.isDirectory()) {
+          TestUtils.copyDirectory(originalFilePath, targetFilePath);
+        }
+      }
+    },
+
+    /**
+     * Recursively deletes a directory, if it exists.
+     *
+     * @param dir path to delete
+     */
+    deleteDirectory: function(dir : string) {
+      if (!fs.existsSync(dir)) {
+        return;
+      }
+      const stat = fs.statSync(dir);
+      if (!stat.isDirectory()) {
+        throw new Error(`Path ${dir} is not a directory. Won't delete!`);
+      }
+
+      for (const file of fs.readdirSync(dir)) {
+        const filePath = path.join(dir, file);
+        const stat = fs.statSync(filePath);
+        if (stat.isFile()) {
+          fs.unlinkSync(filePath);
+        } else if (stat.isDirectory()) {
+          TestUtils.deleteDirectory(filePath);
+        }
+      }
+      fs.rmdirSync(dir);
+    }
+};
+
+export { TestUtils };

--- a/test/suite/test-utils.ts
+++ b/test/suite/test-utils.ts
@@ -13,6 +13,10 @@ const TestUtils = {
       if (fs.existsSync(destination)) {
         throw new Error(`Destination directory (or file) ${destination} already exists, won't copy!`);
       }
+      const stat = fs.statSync(source);
+      if (!stat.isDirectory()) {
+        throw new Error(`Source path ${source} is not a directory. Won't copy!`);
+      }
 
       fs.mkdirSync(destination);
       for (const file of fs.readdirSync(source)) {


### PR DESCRIPTION
The new property `apexPMD.apexRootDirectory` controls, how the environment variable `PMD_APEX_ROOT_DIRECTORY` is determined:

* `{"mode": "automatic"}` - this is the default setting. It searches the directory tree upwards to find the nearest file `sfdx-project.json`. When found, this directory is used. Otherwise the workspace root directory is used (regardless whether a sfdx-project.json file exists or not).
* `{"mode": "custom", "customValue": "path/to/project"}` - custom setting to bypass the automatic behavior: It uses whatever value is provided as `customValue` for the root directory.
* `{"mode": "off"}` - this disables this feature. Then the environment variable `PMD_APEX_ROOT_DIRECTORY` is not set at all.

Fixes #157

