### PR TITLE
Add test case for #181

### DIFF
--- a/test/assets/project2 - with & and space/README.md
+++ b/test/assets/project2 - with & and space/README.md
@@ -1,0 +1,7 @@
+# project2 - with &amp; and space
+
+The tests uses this folder as `workspaceRootPath` - and the folder name contains spaces and an ampersand.
+This might need to be quoted, depending on the operating system.
+The ampersand is often used as a conditional operator to execute two commands (AND logic).
+
+This tests issue [#181](https://github.com/ChuckJonas/vscode-apex-pmd/issues/181)

--- a/test/assets/project2 - with & and space/test.cls
+++ b/test/assets/project2 - with & and space/test.cls
@@ -1,0 +1,10 @@
+// test case for https://github.com/ChuckJonas/vscode-apex-pmd/issues/181
+
+// Test apex that should return a single error
+public class Test {
+    public Test() {
+        while (true) {
+            Account acc = [SELECT Id FROM Account]; // expected violation from rule: Performance-OperationWithLimitsInLoop
+        }
+    }
+}

--- a/test/suite/extension.test.ts
+++ b/test/suite/extension.test.ts
@@ -140,6 +140,43 @@ suite('Extension Tests', () => {
       });
   });
 
+  test('test workspace root path with spaces and ampersand (#181)', function (done) {
+    this.timeout(100000);
+
+    const workspaceRootPath = path.join(TEST_ASSETS_PATH, 'project2 - with & and space');
+    const apexClassFile = path.join(workspaceRootPath, 'test.cls');
+
+    const collection = vscode.languages.createDiagnosticCollection('apex-pmd-test');
+
+    const config = new Config();
+    config.pmdBinPath = PMD_PATH;
+    config.rulesets = [RULESET_PATH];
+    config.priorityErrorThreshold = 3;
+    config.priorityWarnThreshold = 1;
+    config.workspaceRootPath = workspaceRootPath;
+    config.additionalClassPaths = [];
+    config.commandBufferSize = 64000000;
+
+    const pmd = new ApexPmd(outputChannel, config);
+
+    const testApexUri = vscode.Uri.file(apexClassFile);
+    pmd
+      .run(apexClassFile, collection)
+      .then(() => {
+        const errs = collection.get(testApexUri);
+        assert.strictEqual(errs.length, 1);
+
+        const diagnostic = errs[0];
+        const code = diagnostic.code as {value :string };
+        assert.strictEqual(code.value, "OperationWithLimitsInLoop");
+        assert.strictEqual(diagnostic.range.start.line, 6); // vscode lines are 0-based
+        done();
+      })
+      .catch((e) => {
+        done(e);
+      });
+  });
+
   test('test workspace root path with spaces and pmdBinPath with spaces', function (done) {
     this.timeout(100000);
 


### PR DESCRIPTION
Works under Linux...

Let's see, if this also works under Windows and MacOSX...

I think, the culprit is the '&amp;' character in the workspace path...

If not within quotes, this is interpreted as conditional operator -> https://ss64.com/nt/syntax-conditional.html

