### PR TITLE
Bump typescript from 3.8.3 to 5.7.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "prettier": "^2.0.5",
         "ts-loader": "^8.0.2",
         "tslint": "^6.1.3",
-        "typescript": "^3.8.3",
+        "typescript": "^5.7.3",
         "webpack": "^5.94.0",
         "webpack-cli": "^5.1.4"
       },
@@ -3752,16 +3752,16 @@
       }
     },
     "node_modules/typescript": {
-      "version": "3.9.10",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz",
-      "integrity": "sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==",
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
+      "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=4.2.0"
+        "node": ">=14.17"
       }
     },
     "node_modules/update-browserslist-db": {

--- a/package.json
+++ b/package.json
@@ -198,7 +198,7 @@
     "prettier": "^2.0.5",
     "ts-loader": "^8.0.2",
     "tslint": "^6.1.3",
-    "typescript": "^3.8.3",
+    "typescript": "^5.7.3",
     "webpack": "^5.94.0",
     "webpack-cli": "^5.1.4"
   },


### PR DESCRIPTION
Updating typescript from the ancient version 3.8.3 seems to fix the problem, that appears after update webpack (#193)