### PR TITLE
Performance experiments

### DIFF
--- a/package.json
+++ b/package.json
@@ -201,6 +201,16 @@
             "default": true,
             "description": "Make sure to run only 1 PMD process in the background. This avoids running multiple instances in parallel and consume resources.",
             "order": 5
+          },
+          "apexPMD.childProcessMethod": {
+            "type": "string",
+            "enum": [
+              "exec",
+              "execFile",
+              "spawn"
+            ],
+            "default": "exec",
+            "order": 6
           }
         }
       }

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -25,6 +25,7 @@ export class Config {
   public jrePath: string;
   public apexRootDirectory: ApexRootDirectory;
   public limitPMDProcesses: boolean;
+  public childProcessMethod: string;
 
   private _ctx: vscode.ExtensionContext;
 
@@ -60,6 +61,7 @@ export class Config {
     this.jrePath = config.get('jrePath');
     this.apexRootDirectory = config.get('apexRootDirectory');
     this.limitPMDProcesses = config.get('limitPMDProcesses');
+    this.childProcessMethod = config.get('childProcessMethod');
   }
 
   public init() {

--- a/test/suite/pmdExecution.test.ts
+++ b/test/suite/pmdExecution.test.ts
@@ -1,0 +1,109 @@
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+import * as path from 'path';
+import { ApexPmd } from '../../src/extension';
+import { Config } from '../../src/lib/config';
+import * as fs from 'fs';
+import { TestUtils } from './test-utils';
+
+const PMD_PATH = path.join(__dirname, '..', '..', '..', 'bin', 'pmd');
+const RULESET_PATH = path.join(__dirname, '..', '..', '..', 'rulesets', 'apex_ruleset.xml');
+const TEST_ASSETS_PATH = path.join(__dirname, '..', '..', '..', 'test', 'assets');
+const TEST_ASSETS_TEMP_PATH = path.join(__dirname, '..', '..', '..', 'test', 'assets_temp');
+const TEST_APEX_PATH = path.join(TEST_ASSETS_PATH, 'test.cls');
+
+const outputChannel = vscode.window.createOutputChannel('Apex PMD');
+
+suite('PMD Execution related tests', () => {
+  test('test default (exec)', function (done) {
+    this.timeout(100000);
+
+    const collection = vscode.languages.createDiagnosticCollection('apex-pmd-test');
+
+    const config = new Config();
+    config.pmdBinPath = PMD_PATH;
+    config.rulesets = [RULESET_PATH];
+    config.priorityErrorThreshold = 3;
+    config.priorityWarnThreshold = 1;
+    config.workspaceRootPath = '';
+    config.additionalClassPaths = [];
+    config.commandBufferSize = 64000000;
+
+    const pmd = new ApexPmd(outputChannel, config);
+
+    const testApexUri = vscode.Uri.file(TEST_APEX_PATH);
+    pmd
+      .run(TEST_APEX_PATH, collection)
+      .then(() => {
+        const errs = collection.get(testApexUri);
+        assert.strictEqual(errs.length, 1, "Wrong number of found violations");
+        assert.strictEqual(errs[0].message, "Avoid operations in loops that may hit governor limits (rule: Performance-OperationWithLimitsInLoop)");
+        done();
+      })
+      .catch((e) => {
+        done(e);
+      });
+  });
+
+  test('test default (execFile)', function (done) {
+    this.timeout(100000);
+
+    const collection = vscode.languages.createDiagnosticCollection('apex-pmd-test');
+
+    const config = new Config();
+    config.pmdBinPath = PMD_PATH;
+    config.rulesets = [RULESET_PATH];
+    config.priorityErrorThreshold = 3;
+    config.priorityWarnThreshold = 1;
+    config.workspaceRootPath = '';
+    config.additionalClassPaths = [];
+    config.commandBufferSize = 64000000;
+    config.childProcessMethod = 'execFile';
+
+    const pmd = new ApexPmd(outputChannel, config);
+
+    const testApexUri = vscode.Uri.file(TEST_APEX_PATH);
+    pmd
+      .run(TEST_APEX_PATH, collection)
+      .then(() => {
+        const errs = collection.get(testApexUri);
+        assert.strictEqual(errs.length, 1, "Wrong number of found violations");
+        assert.strictEqual(errs[0].message, "Avoid operations in loops that may hit governor limits (rule: Performance-OperationWithLimitsInLoop)");
+        done();
+      })
+      .catch((e) => {
+        done(e);
+      });
+  });
+
+  test('test default (spawn)', function (done) {
+    this.timeout(100000);
+
+    const collection = vscode.languages.createDiagnosticCollection('apex-pmd-test');
+
+    const config = new Config();
+    config.pmdBinPath = PMD_PATH;
+    config.rulesets = [RULESET_PATH];
+    config.priorityErrorThreshold = 3;
+    config.priorityWarnThreshold = 1;
+    config.workspaceRootPath = '';
+    config.additionalClassPaths = [];
+    config.commandBufferSize = 64000000;
+    config.childProcessMethod = 'spawn';
+
+    const pmd = new ApexPmd(outputChannel, config);
+
+    const testApexUri = vscode.Uri.file(TEST_APEX_PATH);
+    pmd
+      .run(TEST_APEX_PATH, collection)
+      .then(() => {
+        const errs = collection.get(testApexUri);
+        assert.strictEqual(errs.length, 1, "Wrong number of found violations");
+        assert.strictEqual(errs[0].message, "Avoid operations in loops that may hit governor limits (rule: Performance-OperationWithLimitsInLoop)");
+        done();
+      })
+      .catch((e) => {
+        done(e);
+      });
+  });
+});


### PR DESCRIPTION
Add some options and logging to analyze performance problems reported in #326.

In theory, "spawn" should be used to call PMD, avoiding the buffering problem. Switching to this by default would make the config option `commandBufferSize` unnecessary.

A simple counter can prevent PMD processes from piling up. Maybe we should cancel the old one and start a new one?


New config options:
* `limitPMDProcesses`: enabled by default. **new behavior** - this could serve as a hotfix, but doesn't address the unknown root cause.
* `childProcessMethod`: by default "exec". Can be changed to "execFile" and "spawn" to test, which one is "faster".

