### PR TITLE
Bump minimum version of VS Code API from 1.43.0 to 1.74.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Bump minimum version of VS Code API from 1.43.0 to 1.74.0 by @adangel in [#345](https://github.com/ChuckJonas/vscode-apex-pmd/pull/345)
 ### Changed
 ### Deprecated
 ### Removed
+- Support for VS Code versions older than November 2022 has been removed via [#345](https://github.com/ChuckJonas/vscode-apex-pmd/pull/345)
 ### Fixed
 ### New Contributors
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
         "webpack-cli": "^6.0.1"
       },
       "engines": {
-        "vscode": "^1.43.0"
+        "vscode": "^1.74.0"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "email": "charlie@callawaycloudconsulting.com"
   },
   "engines": {
-    "vscode": "^1.43.0"
+    "vscode": "^1.74.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
1.74.0 (November 2022)
1.43.0 (March 2020)

This enables us to use https://code.visualstudio.com/api/references/vscode-api#LogOutputChannel

Given that November 2022 is about 2.5 years ago, this shouldn't be such a breaking change...